### PR TITLE
bugfix: refresh-data not a valid identifier

### DIFF
--- a/tao/shell-script/lib/common.sh
+++ b/tao/shell-script/lib/common.sh
@@ -222,7 +222,7 @@ function status() {
     
 }
 
-function refresh-data() {
+function refreshdata() {
   aws quicksight create-ingestion --ingestion-id `date +%Y_%m_%H_%M` --aws-account-id ${account} --data-set-id ${dataSetId}
 }
 function update() {


### PR DESCRIPTION
Before:
```bash
❯ ./shell-script/tao.sh --action=update
/Users/ouj/repos/opensource/aws-cudos-framework-deployment/tao/shell-script/lib/common.sh: line 227: 'refresh-data': not a valid identifier
```

After:
```bash
❯ ./shell-script/tao.sh --action=update
-n AWS CLI version...2.2.38...
ok
-n Fetching AWS Account ID...
```