### PR TITLE
Fix Glue database for CUR2

### DIFF
--- a/cfn-templates/cid-cfn.yml
+++ b/cfn-templates/cid-cfn.yml
@@ -263,7 +263,7 @@ Parameters:
     Type: String
     Description: 'Currency Symbol. Please align with Currency of your CUR. Only supported for China region.'
     Default: "USD"
-    AllowedValues: 
+    AllowedValues:
       # Only currency symbols supported by QS
       - "USD" # US Dollar         $
       - "GBP" # British Pound     £
@@ -294,7 +294,10 @@ Conditions:
         - !Equals [ !Ref DeployKPIDashboard, "yes" ]
   NeedAthenaWorkgroup:  !Equals [ !Ref AthenaWorkgroup, "" ]
   NeedAthenaQueryResultsBucket:  !Equals [ !Ref AthenaQueryResultsBucket, "" ]
-  NeedDatabase: !Equals [ !Ref DatabaseName, "" ]
+  NeedDatabase:
+    Fn::And:
+      - !Equals [ !Ref DatabaseName, "" ]
+      - !Condition NeedLegacyCUR
   NeedCURTable:
     Fn::And:
       - !Equals [ !Ref CURTableName, "" ]
@@ -1873,14 +1876,14 @@ Resources:
           athena_workgroup: !If [ NeedAthenaWorkgroup, !Ref MyAthenaWorkGroup, !Ref AthenaWorkgroup ]
           quicksight_datasource_id: !Select [ 1, !Split [ '/', !GetAtt CidAthenaDataSource.Arn]]
           quicksight_datasource_role_arn: !If [ NeedQuickSightDataSourceRole, !Sub "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/${QuickSightDataSourceRole}", "" ]
-          athena_database: !If [NeedDatabase, !Ref CidDatabase, !Ref DatabaseName ]
+          athena_database: !If [ UseCUR2, !ImportValue cid-DataExports-Database, !If [NeedDatabase, !Ref CidDatabase, !Ref DatabaseName ] ]
           glue_data_catalog: !Ref GlueDataCatalog
           cur_table_name: !If [ UseCUR2, 'cur2', !If [ NeedCURTable, !Ref MyCURTable, !Ref CURTableName ] ]
           cur_database: !If [ UseCUR2, !ImportValue cid-DataExports-Database, !If [NeedDatabase, !Ref CidDatabase, !Ref DatabaseName ] ]
           quicksight_user: !Ref QuickSightUser
           account_map_source: 'dummy' #initial
           share_with_account: !Ref ShareDashboard
-          account_map_database_name: !If [NeedDatabase, !Ref CidDatabase, !Ref DatabaseName ]
+          account_map_database_name: !If [ UseCUR2, !ImportValue cid-DataExports-Database, !If [NeedDatabase, !Ref CidDatabase, !Ref DatabaseName ] ]
           currency_symbol: !Ref CurrencySymbol
     Metadata:
       cfn_nag:
@@ -2212,3 +2215,4 @@ Outputs:
     Description: Technical Value - CidExecArn
     Value: !GetAtt CidExec.Arn
     Export: { Name: !Sub 'cid${Suffix}-CidExecArn'}
+


### PR DESCRIPTION
*Issue #, if available:*
/

*Description of changes:*

When using CUR2, two databases are created in Glue. One from the https://aws-managed-cost-intelligence-dashboards.s3.amazonaws.com/cfn/data-exports-aggregation.yaml
Template: the cid_data_export database:
```
CIDDatabase:
Type: AWS::Glue::Database
Condition: DeployAnyTable
Properties:
DatabaseInput:
Name: !Join [ '_', !Split [ '-', !Sub '${ResourcePrefix}_data_export' ] ] # replace '-' to '_'
CatalogId: !Sub "${AWS::AccountId}"
```

with the associated Glue crawlers.
And once again, from the cid-cfn.yml template (https://github.com/aws-solutions-library-samples/cloud-intelligence-dashboards-framework/blob/main/cfn-templates/cid-cfn.yml#L1026), the "cid_cur" database but without the associated crawler: https://github.com/aws-solutions-library-samples/cloud-intelligence-dashboards-framework/blob/main/cfn-templates/cid-cfn.yml#L1031, because the condition "NeedCURTable" is not true, as it depends on the condition "NeedLegacyCUR," and this is also not true only for CUR2.
In Quicksight, the datasets are then created based on the incorrectly created database "cid_cur," which contains no data, and the dashboard therefore does not display anything.

The pull request changes the condition "NeedDatabase" which means that the database "cid_data_export" is used consistently.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
