### PR TITLE
Handle paginated results from athena queries

### DIFF
--- a/cid/helpers/athena.py
+++ b/cid/helpers/athena.py
@@ -348,7 +348,8 @@ class Athena(CidBase):
 
     def get_query_results(self, query_id):
         """ Get Query Results """
-        return self.client.get_query_results(QueryExecutionId=query_id)
+        paginator = self.client.get_paginator("get_query_results")
+        return paginator.paginate(QueryExecutionId=query_id).build_full_result()
 
     def parse_response_as_table(self, response, include_header=False):
         """ Return a query response as a table. """


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

When athena has a large result set we run into the page size of 1,000 items. This PR changes get_query_results to use a paginator and depaginate the result set to support those situations.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
