### PR TITLE
FIX EC2 Previous Generation Coverage and EC2 Spot Coverage 

### DIFF
--- a/cid/builtin/core/data/datasets/kpi/kpi_tracker.json
+++ b/cid/builtin/core/data/datasets/kpi/kpi_tracker.json
@@ -49,6 +49,11 @@
                         "SubType": "FLOAT"
                     },
                     {
+                        "Name": "ec2_usage_cost",
+                        "Type": "DECIMAL",
+                        "SubType": "FLOAT"
+                    },
+                    {
                         "Name": "ec2_spot_cost",
                         "Type": "DECIMAL",
                         "SubType": "FLOAT"
@@ -397,6 +402,7 @@
                             "linked_account_id",
                             "spend_all_cost",
                             "ec2_all_cost",
+                            "ec2_usage_cost",
                             "ec2_spot_cost",
                             "ec2_spot_potential_savings",
                             "ec2_previous_generation_cost",

--- a/cid/builtin/core/data/queries/kpi/last_kpi_tracker_view.sql
+++ b/cid/builtin/core/data/queries/kpi/last_kpi_tracker_view.sql
@@ -6,6 +6,7 @@ SELECT DISTINCT
 , spend_all.spend_all_cost
 , spend_all.tags_json
 , instance_all.ec2_all_cost
+, instance_all.ec2_usage_cost
 , instance_all.ec2_spot_cost
 , instance_all.ec2_spot_potential_savings
 , instance_all.ec2_previous_generation_cost
@@ -94,6 +95,7 @@ LEFT JOIN (
    , linked_account_id
    , tags_json
    , "sum"("ec2_all_cost") "ec2_all_cost"
+   , "sum"("ec2_usage_cost") "ec2_usage_cost"
    , "sum"("ec2_spot_cost") "ec2_spot_cost"
    , "sum"("ec2_spot_potential_savings") "ec2_spot_potential_savings"
    , "sum"("ec2_previous_generation_cost") "ec2_previous_generation_cost"

--- a/dashboards/kpi_dashboard/kpi_dashboard.yaml
+++ b/dashboards/kpi_dashboard/kpi_dashboard.yaml
@@ -573,7 +573,7 @@ dashboards:
         Expression: ({EC2 Graviton Coverage})/{EC2 Graviton Goal }
         Name: EC2 Graviton Trend
       - DataSetIdentifier: kpi_tracker
-        Expression: SUM({ec2_previous_generation_cost})/SUM({ec2_all_cost})
+        Expression: SUM({ec2_previous_generation_cost})/SUM({ec2_usage_cost})
         Name: EC2 Previous Generation Coverage
       - DataSetIdentifier: kpi_tracker
         Expression: max(${EC2PreviousGeneration})/100
@@ -587,7 +587,7 @@ dashboards:
         Expression: '{EC2 Previous Generation Goal}/{EC2 Previous Generation Coverage}'
         Name: EC2 Previous Generation Trend
       - DataSetIdentifier: kpi_tracker
-        Expression: SUM({ec2_spot_cost})/SUM({ec2_all_cost})
+        Expression: SUM({ec2_spot_cost})/SUM({ec2_usage_cost})
         Name: EC2 Spot Coverage
       - DataSetIdentifier: kpi_tracker
         Expression: max(${EC2SpotGoal})/100


### PR DESCRIPTION
EC2 Previous Generation Coverage and EC2 Spot Coverage must be computed against ec2_usage_cost, not ec2_all_cost.

*Issue #, if available:*
https://github.com/aws-solutions-library-samples/cloud-intelligence-dashboards-framework/issues/1135

*Description of changes:*
currently the EC2 Previous Generation Coverage and EC2 Spot Coverage are computed against ec2_all_cost while should be computed against the instance usage only

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
