### PR TITLE
add cur2_view

### DIFF
--- a/cid/builtin/core/data/resources.yaml
+++ b/cid/builtin/core/data/resources.yaml
@@ -514,6 +514,8 @@ views:
   summary_view:
     File: queries/cid/summary_view.sql
     dependsOn:
+      views:
+        - cur2_view
       tags: json
       cur2:
         - bill_billing_entity
@@ -556,6 +558,15 @@ views:
         - savings_plan_savings_plan_effective_cost
         - savings_plan_total_commitment_to_date
         - savings_plan_used_commitment
+
+  cur2_view:
+    dependsOn:
+      tags: json
+      cur2: True
+    data: |
+      CREATE OR REPLACE VIEW "cur2" AS
+      SELECT *
+      FROM "${cur2_database}"."${cur2_table_name}"
 
   ec2_running_cost:
     File: queries/cid/ec2_running_cost.sql

--- a/cid/builtin/core/data/resources.yaml
+++ b/cid/builtin/core/data/resources.yaml
@@ -563,7 +563,7 @@ views:
     dependsOn:
       cur2: True
     data: |
-      CREATE OR REPLACE VIEW "cur2" AS
+      CREATE VIEW "cur2" AS
       SELECT *
       FROM "${cur2_database}"."${cur2_table_name}"
 

--- a/cid/builtin/core/data/resources.yaml
+++ b/cid/builtin/core/data/resources.yaml
@@ -561,7 +561,6 @@ views:
 
   cur2_view:
     dependsOn:
-      tags: json
       cur2: True
     data: |
       CREATE OR REPLACE VIEW "cur2" AS

--- a/cid/builtin/core/data/resources.yaml
+++ b/cid/builtin/core/data/resources.yaml
@@ -563,7 +563,7 @@ views:
     dependsOn:
       cur2: True
     data: |
-      CREATE VIEW "cur2" AS
+      CREATE VIEW "cur2_view" AS
       SELECT *
       FROM "${cur2_database}"."${cur2_table_name}"
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

## Motivation

Customers complain that cannot do cur query with cur2 in cud_cur database and they need to switch to cid_data_exports every time. This PR will add cur2_view that can be used as access.  

## Considerations

1. cur2 name can be taken in cid_data_exports
2. * can be problematic when working with cur2_proxy
3. cur2_proxy also can be an option but then it would not be trivial to undersand if cur2 or cur1 was used
4. theoretically we can point all cur views to this view adding a common placeholder for all cur related queries that can be modified centrally.  


## Summary

This pull request introduces the `cur2_view` SQL view and updates dependencies for the `summary_view` in `resources.yaml`.

## Changes

- **Added `cur2_view`:**
  - New view `cur2_view` is defined in `resources.yaml`.
  - The view creates `"cur2"` from the specified `${cur2_database}` and `${cur2_table_name}`.

- **Updated `summary_view` dependencies:**
  - Adds `cur2_view` as a dependency in the `views` section for `summary_view`.
  
## Implementation Details

```yaml
cur2_view:
  dependsOn:
    cur2: True
  data: |
    CREATE VIEW "cur2" AS
    SELECT *
    FROM "${cur2_database}"."${cur2_table_name}"
```

- The `summary_view` now depends on `cur2_view` to create it on reach deployment / update


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
