### PR TITLE
Refactor modules to legacy-terraform, fix S3 bucket lifecycle rules, update documentation

### DIFF
--- a/legacy-terraform/README.md
+++ b/legacy-terraform/README.md
@@ -51,7 +51,7 @@ the GitHub / git source as below.
 
 ```hcl
 module "example" {
-  source = "github.com/aws-samples/aws-cudos-framework-deployment//terraform-modules/<module name>"
+  source = "github.com/aws-samples/aws-cudos-framework-deployment//legacy-terraform/<module name>"
   ...
 }
 ```
@@ -122,7 +122,7 @@ provider "aws" {
 
 # Configure exactly one destination account
 module "cur_data_collection_account" {
-  source = "github.com/aws-samples/aws-cudos-framework-deployment//terraform-modules/cur-setup-destination"
+  source = "github.com/aws-samples/aws-cudos-framework-deployment//legacy-terraform/cur-setup-destination"
 
   source_account_ids = ["1234567890"]
   create_cur         = false # Set to true to create an additional CUR in the aggregation account
@@ -137,7 +137,7 @@ module "cur_data_collection_account" {
 
 # Configure one or more source (payer) accounts
 module "cur_payer" {
-  source = "github.com/aws-samples/aws-cudos-framework-deployment//terraform-modules/cur-setup-source"
+  source = "github.com/aws-samples/aws-cudos-framework-deployment//legacy-terraform/cur-setup-source"
 
   destination_bucket_arn = module.cur_data_collection_account.cur_bucket_arn
 
@@ -172,7 +172,7 @@ used `stack_parameters`.
 # dashboard_deployment.tf
 
 module "cid_dashboards" {
-    source = "github.com/aws-samples/aws-cudos-framework-deployment//terraform-modules/cid-dashboards"
+    source = "github.com/aws-samples/aws-cudos-framework-deployment//legacy-terraform/cid-dashboards"
 
     stack_name      = "Cloud-Intelligence-Dashboards"
     template_bucket = "UPDATEME" # Update with S3 bucket name

--- a/legacy-terraform/cid-dashboards/README.md
+++ b/legacy-terraform/cid-dashboards/README.md
@@ -14,7 +14,7 @@ resources and a custom Lambda function to create the dashboards using `cid-cmd`.
 
 ```hcl
 module "cid_dashboards" {
-    source = "github.com/aws-samples/aws-cudos-framework-deployment//terraform-modules/cid-dashboards"
+    source = "github.com/aws-samples/aws-cudos-framework-deployment//legacy-terraform/cid-dashboards"
 
     stack_name      = "Cloud-Intelligence-Dashboards"
     template_bucket = "UPDATEME"

--- a/legacy-terraform/cur-setup-destination/README.md
+++ b/legacy-terraform/cur-setup-destination/README.md
@@ -23,7 +23,7 @@ provider "aws" {
 }
 
 module "cur_destination" {
-  source = "github.com/aws-samples/aws-cudos-framework-deployment//terraform-modules/cur-setup-destination"
+  source = "github.com/aws-samples/aws-cudos-framework-deployment//legacy-terraform/cur-setup-destination"
 
   source_account_ids = ["1234567890"]
   create_cur         = false # Set to true to create an additional CUR in the aggregation account

--- a/legacy-terraform/cur-setup-destination/main.tf
+++ b/legacy-terraform/cur-setup-destination/main.tf
@@ -60,6 +60,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "this" {
   rule {
     id     = "Object&Version Expiration"
     status = "Enabled"
+    filter {}
     noncurrent_version_expiration {
       noncurrent_days = 32
     }

--- a/legacy-terraform/cur-setup-destination/versions.tf
+++ b/legacy-terraform/cur-setup-destination/versions.tf
@@ -5,7 +5,7 @@ terraform {
       source  = "hashicorp/aws"
       version = ">= 3.0"
       configuration_aliases = [
-        aws.useast1,
+        aws.useast1
       ]
     }
   }

--- a/legacy-terraform/cur-setup-source/README.md
+++ b/legacy-terraform/cur-setup-source/README.md
@@ -24,7 +24,7 @@ provider "aws" {
 
 # Configure one or more source (payer) accounts
 module "cur_source" {
-  source = "github.com/aws-samples/aws-cudos-framework-deployment//terraform-modules/cur-setup-source"
+  source = "github.com/aws-samples/aws-cudos-framework-deployment//legacy-terraform/cur-setup-source"
 
   destination_bucket_arn = "UPDATEME"
 

--- a/legacy-terraform/cur-setup-source/main.tf
+++ b/legacy-terraform/cur-setup-source/main.tf
@@ -267,7 +267,7 @@ resource "aws_cur_report_definition" "this" {
   compression                = "Parquet"
   additional_schema_elements = var.enable_split_cost_allocation_data ? ["RESOURCES", "SPLIT_COST_ALLOCATION_DATA"] : ["RESOURCES"]
   s3_bucket                  = aws_s3_bucket.this.bucket
-  s3_region                  = data.aws_region.this.name
+  s3_region                  = data.aws_region.this.id 
   s3_prefix                  = "cur/${data.aws_caller_identity.this.account_id}"
   additional_artifacts       = ["ATHENA"]
   report_versioning          = "OVERWRITE_REPORT"

--- a/legacy-terraform/cur-setup-source/main.tf
+++ b/legacy-terraform/cur-setup-source/main.tf
@@ -59,6 +59,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "this" {
   rule {
     id     = "Object&Version Expiration"
     status = "Enabled"
+    filter {}
     noncurrent_version_expiration {
       noncurrent_days = 32
     }

--- a/legacy-terraform/cur-setup-source/versions.tf
+++ b/legacy-terraform/cur-setup-source/versions.tf
@@ -5,7 +5,7 @@ terraform {
       source  = "hashicorp/aws"
       version = ">= 3.0"
       configuration_aliases = [
-        aws.useast1,
+        aws.useast1
       ]
     }
   }


### PR DESCRIPTION
**Title:**
Refactor modules to **legacy-terraform, fix S3 bucket lifecycle rules, update documentation**

**Summary**
Updated all module source paths from terraform-modules/ to legacy-terraform/ in configuration files and documentation for clarity and consistency.

Added the required **filter {} block to all aws_s3_bucket_lifecycle_configuration resources** in cur-setup-destination and cur-setup-source modules to comply with the latest AWS provider validation requirements.

Fixed a reference from **data.aws_region.this.name to data.aws_region.this.id** in cur-setup-source/main.tf for correctness.

Performed minor formatting and documentation improvements across README files.

**Motivation & Context**
These changes:

Address AWS provider warnings about missing filter attributes in S3 lifecycle rules, preventing future validation errors.

Align all documentation and examples to the new legacy-terraform directory, reducing confusion for users.

Improve maintainability and onboarding for new contributors.

**Testing**
 Ran **terraform validate** on modified modules—no warnings or errors remain.

 Manually reviewed all documentation and code references to ensure consistency and accuracy.

**Checklist**
 All code changes tested and validated.

 Documentation updated to match code.

 Changes introduce no breaking changes for existing users.

 Ready for review.