### PR TITLE
update documentation and S3 region reference to use aws_region.id

### DIFF
--- a/legacy-terraform/README.md
+++ b/legacy-terraform/README.md
@@ -51,7 +51,7 @@ the GitHub / git source as below.
 
 ```hcl
 module "example" {
-  source = "github.com/aws-samples/aws-cudos-framework-deployment//terraform-modules/<module name>"
+  source = "github.com/aws-samples/aws-cudos-framework-deployment//legacy-terraform/<module name>"
   ...
 }
 ```

--- a/legacy-terraform/cur-setup-destination/main.tf
+++ b/legacy-terraform/cur-setup-destination/main.tf
@@ -221,7 +221,7 @@ resource "aws_cur_report_definition" "this" {
   compression                = "Parquet"
   additional_schema_elements = var.enable_split_cost_allocation_data ? ["RESOURCES", "SPLIT_COST_ALLOCATION_DATA"] : ["RESOURCES"]
   s3_bucket                  = aws_s3_bucket.this.bucket
-  s3_region                  = data.aws_region.this.name
+  s3_region                  = data.aws_region.this.id
   s3_prefix                  = "cur/${data.aws_caller_identity.this.account_id}"
   additional_artifacts       = ["ATHENA"]
   report_versioning          = "OVERWRITE_REPORT"


### PR DESCRIPTION
Changed references from terraform-module to legacy-terraform.

Updated S3 region reference: replaced aws_region.name with aws_region.id.
