### PR TITLE
Fix issue #1283 - Command line parsing issue for database and table in cur

### DIFF
--- a/cid/helpers/cur.py
+++ b/cid/helpers/cur.py
@@ -299,7 +299,7 @@ class CUR(AbstractCUR):
         )
         if answer == '<CREATE CUR TABLE AND CRAWLER>':
             raise CidCritical('CUR creation was requested') # to be captured in common.py
-        database, table = answer
+        database, table = answer.split(".")
         set_parameters({'cur-table-name': table,'cur-database': database, })
         return database, self.athena.get_table_metadata(table, database_name=database)
 

--- a/cid/helpers/cur.py
+++ b/cid/helpers/cur.py
@@ -299,7 +299,10 @@ class CUR(AbstractCUR):
         )
         if answer == '<CREATE CUR TABLE AND CRAWLER>':
             raise CidCritical('CUR creation was requested') # to be captured in common.py
-        database, table = answer.split(".")
+        if isinstance(answer, str) and '.' in answer and len(answer.split('.')) == 2:
+            database, table = answer.split('.')
+        else:
+            database, table = answer
         set_parameters({'cur-table-name': table,'cur-database': database, })
         return database, self.athena.get_table_metadata(table, database_name=database)
 


### PR DESCRIPTION
*Issue* #1283 

*Description of changes:*

Split the parameter over the . (DOT)
```
database, table = answer.split(".")
```
Then, I was able to run the following command line without issue
```
cid-cmd update --force --recursive --dashboard-id kpi_dashboard --on-drif override --yes \
     --athena-database "cid_cur" --athena-workgroup CID --cur-table-name-and-db "cid_cur.cur" \
     --resource-tags '' --timezone 'Europe/Rome' --taxonomy '[]'
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
