### PR TITLE
Fix: align Google Cloud ServiceCategory with AWS format (Fixes #1291)

### DIFF
--- a/dashboards/focus/focus_consolidation_view/focus_consolidation_view.sql
+++ b/dashboards/focus/focus_consolidation_view/focus_consolidation_view.sql
@@ -195,7 +195,7 @@ SELECT
 , null ResourceId
 , null ResourceName
 , null ResourceType
-, array_join(ServiceCategory, ',') ServiceCategory
+, element_at(ServiceCategory, 2) ServiceCategory
 , ServiceName
 , SkuId
 , SkuPriceId


### PR DESCRIPTION
## Description
This PR fixes the issue where Google Cloud `ServiceCategory` in the FOCUS dataset was being handled as a concatenated array.  
Instead of joining the array elements, this change ensures that the **second element of the array** is used as the `ServiceCategory`.  

## Background
In Google Cloud FOCUS exports, the `ServiceCategory` field is delivered as an array.  
For example:  [GCP, Network, Cloud Armor, Cloud Armor Standard, Paygo, Rule]
The second element (`Network` in this example) represents the actual `ServiceCategory` that should be aligned with AWS and other providers.

## Related Issue
Fixes #1291 