### PR TITLE
fix: correct wording of taxonomy fields during export.

### DIFF
--- a/cid/export.py
+++ b/cid/export.py
@@ -479,7 +479,7 @@ def export_analysis(qs, athena, glue):
 
         taxonomy_fields = detect_global_filter_fields(definition)
         taxonomy_fields = get_parameter('taxonomy',
-            message='leave only taxonomy filed you want to keep in export',
+            message='Enter the fields that you want removed from the taxonomy before export',
             choices=taxonomy_fields,
             default=[],
             multi=True


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Wording of taxonomy fields question during cid-cmd export function provided incorrect wording that was confusing, indicating the opposite of what fields being provided would do.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
