### PR TITLE
Fix cross-dataset filter to show union of values

### DIFF
--- a/cid/helpers/quicksight/dashboard_patching.py
+++ b/cid/helpers/quicksight/dashboard_patching.py
@@ -173,8 +173,7 @@ def add_filter_to_dashboard_definition(dashboard_definition: Dict[str, Any], fie
                         "Configuration": {
                             "FilterListConfiguration": {
                                 "MatchOperator": "CONTAINS",
-                                "NullOption": "ALL_VALUES",
-                                "SelectAllOptions": "FILTER_ALL_VALUES"
+                                "NullOption": "ALL_VALUES"
                             }
                         },
                         "DefaultFilterControlConfiguration": {


### PR DESCRIPTION
Remove SelectAllOptions FILTER_ALL_VALUES from cross-dataset filters to display all unique values across datasets instead of only common values.

Previously: Dataset A [a,b,c] + Dataset B [c,d] = filter shows [c]
Now: Dataset A [a,b,c] + Dataset B [c,d] = filter shows [a,b,c,d]

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
