### PR TITLE
bug fix for RLS - missing LogicalTableMap in the yaml

### DIFF
--- a/dashboards/rls/rls.yaml
+++ b/dashboards/rls/rls.yaml
@@ -67,6 +67,11 @@ datasets:
               Type: STRING
             - Name: permission_type
               Type: STRING
+      LogicalTableMap:
+        3ed793b5-9318-41ff-b172-e762a9967ec0:
+          Alias: rls_all_users_view
+          Source:
+            PhysicalTableId: a4a17683-2fe9-4d08-9935-95ed1af884bb
       ImportMode: SPICE
     dependsOn:
       views:


### PR DESCRIPTION
*Issue #, if available:* 
missing LogicalTableMap in the yaml which caused the cid-cmd command to fail

*Description of changes:*
Added LogicalTableMap in the yaml

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
