### PR TITLE
Adds permissions to athena:GetWorkGroup

### DIFF
--- a/cfn-templates/cid-cfn.yml
+++ b/cfn-templates/cid-cfn.yml
@@ -1352,6 +1352,7 @@ Resources:
                   - athena:GetQueryResultsStream
                   - athena:ListTableMetadata
                   - athena:GetTableMetadata
+                  - athena:GetWorkGroup
                 Resource:
                   - !Sub 'arn:${AWS::Partition}:athena:${AWS::Region}:${AWS::AccountId}:datacatalog/${GlueDataCatalog}'
                   - Fn::If:


### PR DESCRIPTION
For custom SQL in datasets Quick Suite experiences: `SERVICE_EXCEPTION` with details:

> You are not authorized to perform: athena:GetWorkGroup on the resource. After your AWS administrator or you have updated your permissions, please try again.

*Description of changes:* This adds GetWorkGroup as advised by https://docs.aws.amazon.com/quicksuite/latest/userguide/athena.html.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
