### PR TITLE
Fix issue for RLS command line rls=CLEAR

### DIFF
--- a/cid/common.py
+++ b/cid/common.py
@@ -1697,7 +1697,7 @@ class Cid():
             if isinstance(found_dataset, Dataset) and "RowLevelPermissionDataSet" in found_dataset.raw:
                 del found_dataset.raw["RowLevelPermissionDataSet"]
 
-        if rls_dataset_id or rls_dataset_status:
+        elif rls_dataset_id or rls_dataset_status:
             if not rls_dataset_id:
                 for ds in self.qs.list_data_sets():
                     print(ds)


### PR DESCRIPTION
*Issue #, if available:* 
1. error: in create_or_update_dataset 
    if "RowLevelPermissionDataSet" in found_dataset:
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: argument of type 'Dataset' is not iterable

2. "CLEAR" is not allowed in API. 

*Description of changes:*
Fix the two issues 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
