### PR TITLE
Fix: Add tags_json to msih_view and make tag columns null-safe

### DIFF
--- a/dashboards/media-services-insights/msih.yaml
+++ b/dashboards/media-services-insights/msih.yaml
@@ -593,12 +593,12 @@ datasets:
               Columns:
               - ColumnName: tag_cost_center
                 ColumnId: 1971599a-c062-5962-8087-aa1e44db949c
-                Expression: parseJson(tags_json, '$.tag_cost_center')
+                Expression: ifelse(isNull({tags_json}) OR {tags_json} = '{}', NULL, parseJson({tags_json}, '$.tag_cost_center'))
           - CreateColumnsOperation:
               Columns:
               - ColumnName: tag_business_unit
                 ColumnId: c9a78250-5c66-57f0-ac6f-5c9ac7344b8d
-                Expression: parseJson(tags_json, '$.tag_business_unit')
+                Expression: ifelse(isNull({tags_json}) OR {tags_json} = '{}', NULL, parseJson({tags_json}, '$.tag_business_unit'))
           - CreateColumnsOperation:
               Columns:
               - ColumnName: linked_account_formatted
@@ -1146,6 +1146,7 @@ views:
       , "pricing_unit" "pricing_unit"
       , "line_item_resource_id" "resource_id"
       , "reservation_id"
+      , IF(cardinality(MAP_FILTER(resource_tags, (k, v) -> v IS NOT NULL AND v <> '')) > 0, json_format(CAST(MAP_FILTER(resource_tags, (k, v) -> v IS NOT NULL AND v <> '') AS JSON)), NULL) "tags_json"
       , "reservation_count"
       , "reservation_start_date" "reservation_start_time"
       , "reservation_end_date" "reservation_end_time"
@@ -1169,4 +1170,4 @@ views:
          WHERE ("line_item_usage_start_date" <= (date_trunc('day', current_timestamp) - INTERVAL  '0' DAY))
          GROUP BY 1
       )  ts ON ("bill_payer_account_id" = "payer_account_id"))
-      GROUP BY 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43
+      GROUP BY 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40


### PR DESCRIPTION
The Media Services Insights dashboard deployment fails with CONTEXTUAL_UNKNOWN_SYMBOL error on tag_cost_center because the Athena view doesn't include tags_json, which the QuickSight dataset definition depends on.

Changes:

1. msih_view SQL — Added tags_json column derived from CUR2 resource_tags MAP, using json_format for Athena VARCHAR compatibility: sql IF(cardinality(MAP_FILTER(resource_tags, (k, v) -> v IS NOT NULL AND v <> '')) > 0, json_format(CAST(MAP_FILTER(resource_tags, (k, v) -> v IS NOT NULL AND v <> '') AS JSON)), NULL) "tags_json"
   

2. QuickSight dataset definition — Made tag_cost_center and tag_business_unit calculated columns null-safe to handle customers with no tags:
  
   ifelse(isNull({tags_json}) OR {tags_json} = '{}', NULL, parseJson({tags_json}, '$.tag_cost_center'))
   

Root cause:

The Athena view (msih_view) did not include tags_json in its SELECT, but the QuickSight dataset unconditionally referenced it via parseJson, causing CreateDataSet to fail for any customer where the view lacked tag data.

Notes:
- Empty tag maps return NULL instead of '{}' to avoid Athena cast errors on empty JSON objects
- Athena views don't support JSON column types, so json_format() is used to output VARCHAR
- The null-safe ifelse in QuickSight handles both NULL and empty '{}' cases

Testing:

Verified against a customer deployment where the original error occurred. Dashboard deploys and SPICE syncs successfully after the fix.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
