### PR TITLE
Fix/ext supp account map dataset

### DIFF
--- a/changes/CHANGELOG-extended-support-cost-projection.md
+++ b/changes/CHANGELOG-extended-support-cost-projection.md
@@ -1,5 +1,23 @@
 # What's new in Extended Support Cost Projection
 
+## Extended Support Cost Projection - v5.2.0
+
+**Important:** This version requires the data collection version 3.2.0+. Update to this version requires a forced update. Since this is a major version upgrade, the `cid-cmd` tool will ask to confirm a recursive update or not. Please make sure to confirm the recursive update by answering **yes** to continue the update process and have the view queries and datasets updated.
+
+If you have modified the Extended Support Cost Projection dashboard visuals, these changes will be overridden when the dashboard is updated. Consider backing-up the existing dashboard by creating an analysis from it if you want to keep a reference to customised visuals so you can re-apply them after the update takes place.
+
+To update run these commands in your CloudShell (recommended) or other terminal:
+
+```
+python3 -m ensurepip --upgrade
+pip3 install --upgrade cid-cmd
+cid-cmd update --dashboard-id extended-support-cost-projection --force --recursive
+```
+
+- Moved account name resolution from Athena view queries to QuickSight dataset joins for RDS, EKS, OpenSearch, and ElastiCache datasets. This improves reliability by sourcing account names directly from the `account_map` table via a LEFT JOIN at the dataset level, avoiding dependency on the join being present in the underlying Athena views.
+- Fixed visual field references for account name across RDS, EKS, OpenSearch, and ElastiCache sheets to reflect the updated dataset join structure.
+- Minor visual adjustments: removed axis offsets and scrollbar range constraints on usage breakdown charts.
+
 ## Extended Support Cost Projection - v5.1.0
 
 - Redesigned RDS, EKS, OpenSearch and Elasticache sheets layout: consolidated visuals and updated positions.

--- a/changes/cloud-intelligence-dashboards.rss
+++ b/changes/cloud-intelligence-dashboards.rss
@@ -5,8 +5,25 @@
     <link>https://docs.aws.amazon.com/guidance/latest/cloud-intelligence-dashboards/</link>
     <atom:link href="https://cid.workshops.aws.dev/feed/cloud-intelligence-dashboards.rss" rel="self" type="application/rss+xml"/>
     <description>The Cloud Intelligence Dashboards is an open-source framework, lovingly cultivated and maintained by a group of customer-obsessed AWSers, that gives customers the power to get high-level and granular insight into their cost and usage data. Supported by the Well-Architected framework, the dashboards can be deployed by any customer using a CloudFormation template or a command-line tool in their environment in under 30 minutes. These dashboards help you to drive financial accountability, optimize cost, track usage goals, implement best-practices for governance, and achieve operational excellence across all your organization.</description>
-    <lastBuildDate>Mon, 20 Apr 2026 12:00:00 GMT</lastBuildDate>
+    <lastBuildDate>Wed, 22 Apr 2026 12:00:00 GMT</lastBuildDate>
     <language>en-us</language>
+    <item>
+      <title>[Update] Extended Support Cost Projection - v5.2.0</title>
+      <link>
+        https://github.com/aws-solutions-library-samples/cloud-intelligence-dashboards-framework/blob/main/changes/CHANGELOG-extended-support-cost-projection.md#extended-support-cost-projection---v520
+      </link>
+      <pubDate>Wed, 22 Apr 2026 12:00:00 GMT</pubDate>
+      <category><![CDATA[Dashboard Update]]></category>
+      <guid isPermaLink="false">47af1668-a7bb-4544-858f-11c8abbbf23e</guid>
+      <description>Extended Support Cost Projection - v5.2.0</description>
+      <content:encoded><![CDATA[
+<div>
+  <ul>
+    <li>Moved account name resolution from Athena view queries to QuickSight dataset joins for RDS, EKS, OpenSearch, and ElastiCache datasets, improving reliability and decoupling account name lookups from the underlying views.</li>
+  </ul>
+</div>
+    ]]></content:encoded>
+    </item>
     <item>
       <title>[Update] CID Data Exports v0.11.0 - Direct Cross-Account Delivery (S3BucketOwner)</title>
       <link>

--- a/dashboards/extended-support-cost-projection/extended-support-cost-projection-definition.yaml
+++ b/dashboards/extended-support-cost-projection/extended-support-cost-projection-definition.yaml
@@ -2286,7 +2286,7 @@ Sheets:
           CategorySort:
           - FieldSort:
               Direction: DESC
-              FieldId: 064649d2-642b-4928-84bd-7861d224298a.account_name.2.1776866153303
+              FieldId: ba51b0b7-2118-49f3-85f2-399ae50255b4.vcpu_acu_hours.1.1707159708427
           ColorItemsLimit:
             OtherCategories: INCLUDE
           ColorSort:
@@ -3685,7 +3685,7 @@ Sheets:
           CategorySort:
           - FieldSort:
               Direction: DESC
-              FieldId: adfdbf7d-6b22-44f9-995e-576b7c3489ed.account_name.2.1776866874331
+              FieldId: 2cbef0f5-bd73-4791-840e-7221b6fb58e0.usage_amount.0.1713268442284
           ColorItemsLimit:
             OtherCategories: INCLUDE
           ColorSort:
@@ -4439,7 +4439,7 @@ Sheets:
           CategorySort:
           - FieldSort:
               Direction: DESC
-              FieldId: f7798214-7469-4dc4-a6c4-90b2dfbd1839.account_name.2.1776867332037
+              FieldId: 6f0bc2eb-2e93-42f6-a747-b4facc207d58.usage_amount.1.1732631212226
           ColorItemsLimit:
             OtherCategories: INCLUDE
           SmallMultiplesLimitConfiguration:
@@ -5576,7 +5576,7 @@ Sheets:
           CategorySort:
           - FieldSort:
               Direction: DESC
-              FieldId: 658a81e9-b100-4a7d-992f-5d7bd5e98b60.account_name.2.1776867528132
+              FieldId: c0037c45-1148-426d-9e1c-7f99c291c297.usage_amount.1.1758274629586
           ColorItemsLimit:
             OtherCategories: INCLUDE
           SmallMultiplesLimitConfiguration:

--- a/dashboards/extended-support-cost-projection/extended-support-cost-projection-definition.yaml
+++ b/dashboards/extended-support-cost-projection/extended-support-cost-projection-definition.yaml
@@ -1814,7 +1814,6 @@ Sheets:
           SelectedTooltipType: DETAILED
           TooltipVisibility: VISIBLE
         ValueAxis:
-          AxisOffset: 58px
           TickLabelOptions:
             LabelOptions:
               FontConfiguration:
@@ -2238,19 +2237,9 @@ Sheets:
         CategoryAxis:
           ScrollbarOptions:
             Visibility: VISIBLE
-            VisibleRange:
-              PercentRange:
-                From: 0.0
-                To: 52.631578947368304
         CategoryLabelOptions:
           AxisLabelOptions:
-          - ApplyTo:
-              Column:
-                ColumnName: account_name
-                DataSetIdentifier: rds_extended_support_view
-              FieldId: ba51b0b7-2118-49f3-85f2-399ae50255b4.account_name.2.1776416441349
-            CustomLabel: Account
-            FontConfiguration:
+          - FontConfiguration:
               FontSize:
                 Absolute: 14px
           SortIconVisibility: HIDDEN
@@ -2271,7 +2260,7 @@ Sheets:
                 Column:
                   ColumnName: account_name
                   DataSetIdentifier: rds_extended_support_view
-                FieldId: ba51b0b7-2118-49f3-85f2-399ae50255b4.account_name.2.1776416441349
+                FieldId: 064649d2-642b-4928-84bd-7861d224298a.account_name.2.1776866153303
             Colors:
             - CategoricalDimensionField:
                 Column:
@@ -2297,7 +2286,7 @@ Sheets:
           CategorySort:
           - FieldSort:
               Direction: DESC
-              FieldId: ba51b0b7-2118-49f3-85f2-399ae50255b4.vcpu_acu_hours.1.1707159708427
+              FieldId: 064649d2-642b-4928-84bd-7861d224298a.account_name.2.1776866153303
           ColorItemsLimit:
             OtherCategories: INCLUDE
           ColorSort:
@@ -2317,13 +2306,11 @@ Sheets:
                 FieldId: bed93a81-0b49-42f4-b097-b2eb6bc19e98.1.1776412070711
                 Visibility: VISIBLE
             - FieldTooltipItem:
-                FieldId: ba51b0b7-2118-49f3-85f2-399ae50255b4.account_name.2.1776416441349
+                FieldId: 064649d2-642b-4928-84bd-7861d224298a.account_name.2.1776866153303
                 Visibility: VISIBLE
             TooltipTitleType: PRIMARY_VALUE
           SelectedTooltipType: DETAILED
           TooltipVisibility: VISIBLE
-        ValueAxis:
-          AxisOffset: 108px
         ValueLabelOptions:
           AxisLabelOptions:
           - ApplyTo:
@@ -2374,7 +2361,7 @@ Sheets:
           - CustomLabel: Linked Account ID
             FieldId: ba51b0b7-2118-49f3-85f2-399ae50255b4.linked_account_id.16.1715260006610
           - CustomLabel: Account Name
-            FieldId: ba51b0b7-2118-49f3-85f2-399ae50255b4.account_name.17.1715261849310
+            FieldId: 064649d2-642b-4928-84bd-7861d224298a.account_name.20.1776866125247
           - CustomLabel: DB Instance ID
             FieldId: ba51b0b7-2118-49f3-85f2-399ae50255b4.dbresourceidentifier.16.1707820559498
             Width: 417px
@@ -2431,7 +2418,7 @@ Sheets:
                 Column:
                   ColumnName: account_name
                   DataSetIdentifier: rds_extended_support_view
-                FieldId: ba51b0b7-2118-49f3-85f2-399ae50255b4.account_name.17.1715261849310
+                FieldId: 064649d2-642b-4928-84bd-7861d224298a.account_name.20.1776866125247
             - CategoricalDimensionField:
                 Column:
                   ColumnName: dbresourceidentifier
@@ -3046,7 +3033,7 @@ Sheets:
           SelectedTooltipType: DETAILED
           TooltipVisibility: VISIBLE
         ValueAxis:
-          AxisOffset: 65px
+          AxisOffset: 59px
           TickLabelOptions:
             LabelOptions:
               FontConfiguration:
@@ -3085,7 +3072,7 @@ Sheets:
           - CustomLabel: Linked Account ID
             FieldId: 2cbef0f5-bd73-4791-840e-7221b6fb58e0.linked_account_id.10.1715262215369
           - CustomLabel: Account Name
-            FieldId: 2cbef0f5-bd73-4791-840e-7221b6fb58e0.account_name.8.1715262207699
+            FieldId: adfdbf7d-6b22-44f9-995e-576b7c3489ed.account_name.10.1776866908091
           - CustomLabel: Cluster Name
             FieldId: 2cbef0f5-bd73-4791-840e-7221b6fb58e0.cluster_name.7.1713269679118
           - CustomLabel: Cluster ARN
@@ -3121,7 +3108,7 @@ Sheets:
                 Column:
                   ColumnName: account_name
                   DataSetIdentifier: eks_extended_support_view
-                FieldId: 2cbef0f5-bd73-4791-840e-7221b6fb58e0.account_name.8.1715262207699
+                FieldId: adfdbf7d-6b22-44f9-995e-576b7c3489ed.account_name.10.1776866908091
             - CategoricalDimensionField:
                 Column:
                   ColumnName: cluster_name
@@ -3649,13 +3636,6 @@ Sheets:
           ScrollbarOptions:
             Visibility: VISIBLE
         CategoryLabelOptions:
-          AxisLabelOptions:
-          - ApplyTo:
-              Column:
-                ColumnName: account_name
-                DataSetIdentifier: eks_extended_support_view
-              FieldId: 2cbef0f5-bd73-4791-840e-7221b6fb58e0.account_name.2.1776435893374
-            CustomLabel: Account
           SortIconVisibility: HIDDEN
           Visibility: VISIBLE
         DataLabels:
@@ -3674,7 +3654,7 @@ Sheets:
                 Column:
                   ColumnName: account_name
                   DataSetIdentifier: eks_extended_support_view
-                FieldId: 2cbef0f5-bd73-4791-840e-7221b6fb58e0.account_name.2.1776435893374
+                FieldId: adfdbf7d-6b22-44f9-995e-576b7c3489ed.account_name.2.1776866874331
             Colors:
             - CategoricalDimensionField:
                 Column:
@@ -3705,7 +3685,7 @@ Sheets:
           CategorySort:
           - FieldSort:
               Direction: DESC
-              FieldId: 2cbef0f5-bd73-4791-840e-7221b6fb58e0.usage_amount.0.1713268442284
+              FieldId: adfdbf7d-6b22-44f9-995e-576b7c3489ed.account_name.2.1776866874331
           ColorItemsLimit:
             OtherCategories: INCLUDE
           ColorSort:
@@ -3725,13 +3705,11 @@ Sheets:
                 FieldId: 635350ad-c237-4477-b0d6-2f5348d9d3cb.1.1776434067174
                 Visibility: VISIBLE
             - FieldTooltipItem:
-                FieldId: 2cbef0f5-bd73-4791-840e-7221b6fb58e0.account_name.2.1776435893374
+                FieldId: adfdbf7d-6b22-44f9-995e-576b7c3489ed.account_name.2.1776866874331
                 Visibility: VISIBLE
             TooltipTitleType: PRIMARY_VALUE
           SelectedTooltipType: DETAILED
           TooltipVisibility: VISIBLE
-        ValueAxis:
-          AxisOffset: 96px
         ValueLabelOptions:
           AxisLabelOptions:
           - ApplyTo:
@@ -4368,7 +4346,7 @@ Sheets:
           SelectedTooltipType: DETAILED
           TooltipVisibility: VISIBLE
         ValueAxis:
-          AxisOffset: 63px
+          AxisOffset: 79px
           TickLabelOptions:
             LabelOptions:
               FontConfiguration:
@@ -4413,13 +4391,6 @@ Sheets:
       ChartConfiguration:
         BarsArrangement: STACKED
         CategoryLabelOptions:
-          AxisLabelOptions:
-          - ApplyTo:
-              Column:
-                ColumnName: account_name
-                DataSetIdentifier: opensearch_extended_support_view
-              FieldId: 6f0bc2eb-2e93-42f6-a747-b4facc207d58.account_name.1.1776436221424
-            CustomLabel: Account
           SortIconVisibility: HIDDEN
         DataLabels:
           CategoryLabelVisibility: HIDDEN
@@ -4437,7 +4408,7 @@ Sheets:
                 Column:
                   ColumnName: account_name
                   DataSetIdentifier: opensearch_extended_support_view
-                FieldId: 6f0bc2eb-2e93-42f6-a747-b4facc207d58.account_name.1.1776436221424
+                FieldId: f7798214-7469-4dc4-a6c4-90b2dfbd1839.account_name.2.1776867332037
             Colors:
             - CategoricalDimensionField:
                 Column:
@@ -4468,7 +4439,7 @@ Sheets:
           CategorySort:
           - FieldSort:
               Direction: DESC
-              FieldId: 6f0bc2eb-2e93-42f6-a747-b4facc207d58.usage_amount.1.1732631212226
+              FieldId: f7798214-7469-4dc4-a6c4-90b2dfbd1839.account_name.2.1776867332037
           ColorItemsLimit:
             OtherCategories: INCLUDE
           SmallMultiplesLimitConfiguration:
@@ -4481,10 +4452,10 @@ Sheets:
                 FieldId: 6f0bc2eb-2e93-42f6-a747-b4facc207d58.usage_amount.1.1732631212226
                 Visibility: VISIBLE
             - FieldTooltipItem:
-                FieldId: 6f0bc2eb-2e93-42f6-a747-b4facc207d58.account_name.1.1776436221424
+                FieldId: 1e155e92-ecdf-4491-9ca8-c92a8451a5e0.2.1776436232154
                 Visibility: VISIBLE
             - FieldTooltipItem:
-                FieldId: 1e155e92-ecdf-4491-9ca8-c92a8451a5e0.2.1776436232154
+                FieldId: f7798214-7469-4dc4-a6c4-90b2dfbd1839.account_name.2.1776867332037
                 Visibility: VISIBLE
             TooltipTitleType: PRIMARY_VALUE
           SelectedTooltipType: DETAILED
@@ -4618,7 +4589,7 @@ Sheets:
             FieldId: 6f0bc2eb-2e93-42f6-a747-b4facc207d58.linked_account_id.1.1732632783557
             Width: 143px
           - CustomLabel: Account Name
-            FieldId: 6f0bc2eb-2e93-42f6-a747-b4facc207d58.account_name.2.1732632788742
+            FieldId: f7798214-7469-4dc4-a6c4-90b2dfbd1839.account_name.15.1776867362907
           - CustomLabel: Domain Name
             FieldId: 6f0bc2eb-2e93-42f6-a747-b4facc207d58.domainname.3.1732632794723
           - CustomLabel: Domain ARN
@@ -4669,7 +4640,7 @@ Sheets:
                 Column:
                   ColumnName: account_name
                   DataSetIdentifier: opensearch_extended_support_view
-                FieldId: 6f0bc2eb-2e93-42f6-a747-b4facc207d58.account_name.2.1732632788742
+                FieldId: f7798214-7469-4dc4-a6c4-90b2dfbd1839.account_name.15.1776867362907
             - CategoricalDimensionField:
                 Column:
                   ColumnName: domainname
@@ -5511,7 +5482,7 @@ Sheets:
           SelectedTooltipType: DETAILED
           TooltipVisibility: VISIBLE
         ValueAxis:
-          AxisOffset: 52px
+          AxisOffset: 44px
           TickLabelOptions:
             LabelOptions:
               FontConfiguration:
@@ -5555,12 +5526,6 @@ Sheets:
         Trigger: DATA_POINT_CLICK
       ChartConfiguration:
         BarsArrangement: STACKED
-        CategoryAxis:
-          ScrollbarOptions:
-            VisibleRange:
-              PercentRange:
-                From: 23.076923076923023
-                To: 100.0
         CategoryLabelOptions:
           SortIconVisibility: HIDDEN
           Visibility: HIDDEN
@@ -5580,7 +5545,7 @@ Sheets:
                 Column:
                   ColumnName: account_name
                   DataSetIdentifier: elasticache_extended_support_view
-                FieldId: c0037c45-1148-426d-9e1c-7f99c291c297.account_name.1.1776437037122
+                FieldId: 658a81e9-b100-4a7d-992f-5d7bd5e98b60.account_name.2.1776867528132
             Colors:
             - CategoricalDimensionField:
                 Column:
@@ -5611,7 +5576,7 @@ Sheets:
           CategorySort:
           - FieldSort:
               Direction: DESC
-              FieldId: c0037c45-1148-426d-9e1c-7f99c291c297.usage_amount.1.1758274629586
+              FieldId: 658a81e9-b100-4a7d-992f-5d7bd5e98b60.account_name.2.1776867528132
           ColorItemsLimit:
             OtherCategories: INCLUDE
           SmallMultiplesLimitConfiguration:
@@ -5624,16 +5589,14 @@ Sheets:
                 FieldId: c0037c45-1148-426d-9e1c-7f99c291c297.usage_amount.1.1758274629586
                 Visibility: VISIBLE
             - FieldTooltipItem:
-                FieldId: c0037c45-1148-426d-9e1c-7f99c291c297.account_name.1.1776437037122
+                FieldId: d207712d-28e9-4ddd-ad91-389337c2d61c.2.1776437041407
                 Visibility: VISIBLE
             - FieldTooltipItem:
-                FieldId: d207712d-28e9-4ddd-ad91-389337c2d61c.2.1776437041407
+                FieldId: 658a81e9-b100-4a7d-992f-5d7bd5e98b60.account_name.2.1776867528132
                 Visibility: VISIBLE
             TooltipTitleType: PRIMARY_VALUE
           SelectedTooltipType: DETAILED
           TooltipVisibility: VISIBLE
-        ValueAxis:
-          AxisOffset: 113px
         ValueLabelOptions:
           AxisLabelOptions:
           - ApplyTo:
@@ -5811,9 +5774,13 @@ Sheets:
             FieldId: c0037c45-1148-426d-9e1c-7f99c291c297.linked_account_id.2.1758277184611
             Width: 129px
           - CustomLabel: Account Name
-            FieldId: c0037c45-1148-426d-9e1c-7f99c291c297.account_name.1.1758277161509
+            FieldId: 658a81e9-b100-4a7d-992f-5d7bd5e98b60.account_name.10.1776867557288
           - CustomLabel: Cache Cluster ID
             FieldId: c0037c45-1148-426d-9e1c-7f99c291c297.cacheclusterid.3.1758277201961
+          - CustomLabel: Region
+            FieldId: c0037c45-1148-426d-9e1c-7f99c291c297.region_code.10.1758278668218
+          - CustomLabel: Engine Version
+            FieldId: c0037c45-1148-426d-9e1c-7f99c291c297.engineversion.9.1758278657651
           - CustomLabel: Instance Type
             FieldId: c0037c45-1148-426d-9e1c-7f99c291c297.instance_type.8.1758277342664
           - CustomLabel: Start of Extended Support
@@ -5841,7 +5808,7 @@ Sheets:
                 Column:
                   ColumnName: account_name
                   DataSetIdentifier: elasticache_extended_support_view
-                FieldId: c0037c45-1148-426d-9e1c-7f99c291c297.account_name.1.1758277161509
+                FieldId: 658a81e9-b100-4a7d-992f-5d7bd5e98b60.account_name.10.1776867557288
             - CategoricalDimensionField:
                 Column:
                   ColumnName: cacheclusterid
@@ -5945,7 +5912,7 @@ Sheets:
       center\">\n    <inline color=\"#61d1d6\">\n      <a href=\"https://docs.aws.amazon.com/guidance/latest/cloud-intelligence-dashboards/extended-support.html\"\
       \ target=\"_blank\">\n        <b>\n          <u>Extended Support Cost Projection</u>\n\
       \        </b>\n      </a>\n    </inline>\n  </block>\n  <br/>\n  <block align=\"\
-      center\">\n    <b>v5.1.0</b>\n  </block>\n  <br/>\n  <block align=\"right\"\
+      center\">\n    <b>v5.2.0</b>\n  </block>\n  <br/>\n  <block align=\"right\"\
       />\n  <br/>\n  <block align=\"center\"/>\n  <br/>\n  <block align=\"center\"\
       />\n  <br/>\n  <block align=\"right\">Built by: Julio Chaves, Yuriy Prykhodko,\
       \ Iakov Gan, Eric Christensen, Sumit Agarwal</block>\n  <br/>\n  <block align=\"\

--- a/dashboards/extended-support-cost-projection/extended-support-cost-projection.yaml
+++ b/dashboards/extended-support-cost-projection/extended-support-cost-projection.yaml
@@ -20,7 +20,7 @@ dashboards:
     - line_item_product_code
     - tags_json
     file: ./extended-support-cost-projection-definition.yaml
-    version: v5.1.0
+    version: v5.2.0
 datasets:
   elasticache_extended_support_view:
     data:
@@ -90,9 +90,20 @@ datasets:
             - Name: ext_sup_year_3_price
               Type: DECIMAL
               SubType: FLOAT
+        19e7f4ff-203f-478e-a12e-754ee6a312cb:
+          RelationalTable:
+            DataSourceArn: ${athena_datasource_arn}
+            Catalog: AwsDataCatalog
+            Schema: ${account_map_database_name}
+            Name: account_map
+            InputColumns:
+            - Name: account_id
+              Type: STRING
+            - Name: account_name
+              Type: STRING
       LogicalTableMap:
-        c0037c45-1148-426d-9e1c-7f99c291c297:
-          Alias: elasticache_extended_support_view
+        6470784a-be08-4645-a95d-16902c3923ae:
+          Alias: Intermediate Table
           DataTransforms:
           - ProjectOperation:
               ProjectedColumns:
@@ -100,7 +111,6 @@ datasets:
               - usage_date
               - payer_account_id
               - linked_account_id
-              - account_name
               - engine
               - region_code
               - engineversion
@@ -121,14 +131,38 @@ datasets:
               - ext_sup_year_1_2_price
               - year_3_cost
               - ext_sup_year_3_price
+              - account_id
+              - account_name
+          Source:
+            JoinInstruction:
+              LeftOperand: c0037c45-1148-426d-9e1c-7f99c291c297
+              RightOperand: 658a81e9-b100-4a7d-992f-5d7bd5e98b60
+              Type: LEFT
+              OnClause: '{linked_account_id} = {account_id}'
+        658a81e9-b100-4a7d-992f-5d7bd5e98b60:
+          Alias: account_map
+          Source:
+            PhysicalTableId: 19e7f4ff-203f-478e-a12e-754ee6a312cb
+        c0037c45-1148-426d-9e1c-7f99c291c297:
+          Alias: elasticache_extended_support_view
           Source:
             PhysicalTableId: a201689c-b688-4037-a5ad-6282c4056d01
       ImportMode: SPICE
     dependsOn:
       views:
+      - account_map
       - elasticache_extended_support_view
     schedules:
     - default
+    parameters:
+      account_map_database_name:
+        type: athena
+        query: SELECT DISTINCT table_schema FROM information_schema.columns WHERE table_name = 'account_map'
+        error: "This means that prerequisites for the dashboard are not found. Please make sure you have the needed table: Data Collection installed, needed module is configured and Step Function runs correctly."
+        error: You need to install Foundational Dashboards that provide account_map view.
+        default: cid_cur
+        description: Database of account_map table (from foundational dashboards)
+        global: True
   eks_extended_support_view:
     data:
       DataSetId: 321e897c-7912-4cfd-bd4c-d15d0f948127
@@ -177,9 +211,24 @@ datasets:
               Type: DATETIME
             - Name: is_out_of_extended_support
               Type: STRING
+        effd7cff-853e-45ff-b71d-b08cd0117824:
+          RelationalTable:
+            DataSourceArn: ${athena_datasource_arn}
+            Catalog: AwsDataCatalog
+            Schema: ${account_map_database_name}
+            Name: account_map
+            InputColumns:
+            - Name: account_id
+              Type: STRING
+            - Name: account_name
+              Type: STRING
       LogicalTableMap:
         2cbef0f5-bd73-4791-840e-7221b6fb58e0:
           Alias: eks_extended_support_view
+          Source:
+            PhysicalTableId: 2ae1dbc5-c18b-4751-8473-5864f5e91d44
+        42ee4bbc-a6c6-4df1-ab20-09546ec05fd4:
+          Alias: Intermediate Table
           DataTransforms:
           - ProjectOperation:
               ProjectedColumns:
@@ -187,7 +236,6 @@ datasets:
               - usage_date
               - payer_account_id
               - linked_account_id
-              - account_name
               - region_code
               - original_usage_type
               - k8s_version
@@ -200,19 +248,50 @@ datasets:
               - extended_support_cost
               - end_of_extended_support
               - is_out_of_extended_support
+              - account_id
+              - account_name
           Source:
-            PhysicalTableId: 2ae1dbc5-c18b-4751-8473-5864f5e91d44
+            JoinInstruction:
+              LeftOperand: 2cbef0f5-bd73-4791-840e-7221b6fb58e0
+              RightOperand: adfdbf7d-6b22-44f9-995e-576b7c3489ed
+              Type: LEFT
+              OnClause: '{linked_account_id} = {account_id}'
+        adfdbf7d-6b22-44f9-995e-576b7c3489ed:
+          Alias: account_map
+          Source:
+            PhysicalTableId: effd7cff-853e-45ff-b71d-b08cd0117824
       ImportMode: SPICE
     dependsOn:
       views:
       - eks_extended_support_view
+      - account_map
     schedules:
     - default
+    parameters:
+      account_map_database_name:
+        type: athena
+        query: SELECT DISTINCT table_schema FROM information_schema.columns WHERE table_name = 'account_map'
+        error: "This means that prerequisites for the dashboard are not found. Please make sure you have the needed table: Data Collection installed, needed module is configured and Step Function runs correctly."
+        error: You need to install Foundational Dashboards that provide account_map view.
+        default: cid_cur
+        description: Database of account_map table (from foundational dashboards)
+        global: True
   rds_extended_support_view:
     data:
       DataSetId: 31961243-0137-4201-a8d1-c2a00755765e
       Name: rds_extended_support_view
       PhysicalTableMap:
+        0d4de22c-5e16-47c0-bf31-c248baf48499:
+          RelationalTable:
+            DataSourceArn: ${athena_datasource_arn}
+            Catalog: AwsDataCatalog
+            Schema: ${account_map_database_name}
+            Name: account_map
+            InputColumns:
+            - Name: account_id
+              Type: STRING
+            - Name: account_name
+              Type: STRING
         76a6ad9d-caf0-447f-8609-1c4d8fb89673:
           RelationalTable:
             DataSourceArn: ${athena_datasource_arn}
@@ -289,8 +368,12 @@ datasets:
               Type: DECIMAL
               SubType: FLOAT
       LogicalTableMap:
-        ba51b0b7-2118-49f3-85f2-399ae50255b4:
-          Alias: rds_extended_support_view
+        064649d2-642b-4928-84bd-7861d224298a:
+          Alias: account_map
+          Source:
+            PhysicalTableId: 0d4de22c-5e16-47c0-bf31-c248baf48499
+        18c4c51f-5008-444e-ae9f-2874e670d8f1:
+          Alias: Intermediate Table
           DataTransforms:
           - ProjectOperation:
               ProjectedColumns:
@@ -298,7 +381,6 @@ datasets:
               - usage_date
               - payer_account_id
               - linked_account_id
-              - account_name
               - region_code
               - rds_type
               - deployment_option
@@ -325,14 +407,34 @@ datasets:
               - year_1_2_cost
               - year_3_pricing
               - year_3_cost
+              - account_id
+              - account_name
+          Source:
+            JoinInstruction:
+              LeftOperand: ba51b0b7-2118-49f3-85f2-399ae50255b4
+              RightOperand: 064649d2-642b-4928-84bd-7861d224298a
+              Type: LEFT
+              OnClause: '{linked_account_id} = {account_id}'
+        ba51b0b7-2118-49f3-85f2-399ae50255b4:
+          Alias: rds_extended_support_view
           Source:
             PhysicalTableId: 76a6ad9d-caf0-447f-8609-1c4d8fb89673
       ImportMode: SPICE
     dependsOn:
       views:
+      - account_map
       - rds_extended_support_view
     schedules:
     - default
+    parameters:
+      account_map_database_name:
+        type: athena
+        query: SELECT DISTINCT table_schema FROM information_schema.columns WHERE table_name = 'account_map'
+        error: "This means that prerequisites for the dashboard are not found. Please make sure you have the needed table: Data Collection installed, needed module is configured and Step Function runs correctly."
+        error: You need to install Foundational Dashboards that provide account_map view.
+        default: cid_cur
+        description: Database of account_map table (from foundational dashboards)
+        global: True
   opensearch_extended_support_view:
     data:
       DataSetId: ecb9e3a1-3e67-482a-989c-1c403c8bd912
@@ -394,9 +496,24 @@ datasets:
             - Name: projected_extended_support_cost
               Type: DECIMAL
               SubType: FLOAT
+        cbd42501-c0e4-4cb5-a85f-50cbaa20776e:
+          RelationalTable:
+            DataSourceArn: ${athena_datasource_arn}
+            Catalog: AwsDataCatalog
+            Schema: ${account_map_database_name}
+            Name: account_map
+            InputColumns:
+            - Name: account_id
+              Type: STRING
+            - Name: account_name
+              Type: STRING
       LogicalTableMap:
         6f0bc2eb-2e93-42f6-a747-b4facc207d58:
           Alias: opensearch_extended_support_view
+          Source:
+            PhysicalTableId: b51ef4eb-f8bd-41d1-8ed4-bce50612fb1b
+        bcdd7260-ea8b-41ab-a0bd-4c300b110bd3:
+          Alias: Intermediate Table
           DataTransforms:
           - ProjectOperation:
               ProjectedColumns:
@@ -404,7 +521,6 @@ datasets:
               - usage_date
               - payer_account_id
               - linked_account_id
-              - account_name
               - region_code
               - domainname
               - domainidentifier
@@ -422,14 +538,34 @@ datasets:
               - end_of_extended_support
               - nih_pricing
               - projected_extended_support_cost
+              - account_id
+              - account_name
           Source:
-            PhysicalTableId: b51ef4eb-f8bd-41d1-8ed4-bce50612fb1b
+            JoinInstruction:
+              LeftOperand: 6f0bc2eb-2e93-42f6-a747-b4facc207d58
+              RightOperand: f7798214-7469-4dc4-a6c4-90b2dfbd1839
+              Type: LEFT
+              OnClause: '{linked_account_id} = {account_id}'
+        f7798214-7469-4dc4-a6c4-90b2dfbd1839:
+          Alias: account_map
+          Source:
+            PhysicalTableId: cbd42501-c0e4-4cb5-a85f-50cbaa20776e
       ImportMode: SPICE
     dependsOn:
       views:
       - opensearch_extended_support_view
+      - account_map
     schedules:
     - default
+    parameters:
+      account_map_database_name:
+        type: athena
+        query: SELECT DISTINCT table_schema FROM information_schema.columns WHERE table_name = 'account_map'
+        error: "This means that prerequisites for the dashboard are not found. Please make sure you have the needed table: Data Collection installed, needed module is configured and Step Function runs correctly."
+        error: You need to install Foundational Dashboards that provide account_map view.
+        default: cid_cur
+        description: Database of account_map table (from foundational dashboards)
+        global: True
   extended_support_tagging_view:
     data:
       DataSetId: 0655eb28-3f36-4a5d-8e8a-c2d70cd09fc7
@@ -446,6 +582,8 @@ datasets:
               Type: STRING
             - Name: tags_json
               Type: STRING
+            - Name: rows
+              Type: INTEGER
       LogicalTableMap:
         30248d27-4a3a-4350-bf1d-dd382f040c95:
           Alias: extended_support_tagging_view
@@ -454,6 +592,7 @@ datasets:
               ProjectedColumns:
               - line_item_product_code
               - tags_json
+              - rows
           Source:
             PhysicalTableId: 5a574f8c-5e74-4da8-97cc-4f6802a7d360
       ImportMode: SPICE
@@ -462,6 +601,15 @@ datasets:
       - extended_support_tagging_view
     schedules:
     - default
+    parameters:
+      account_map_database_name:
+        type: athena
+        query: SELECT DISTINCT table_schema FROM information_schema.columns WHERE table_name = 'account_map'
+        error: "This means that prerequisites for the dashboard are not found. Please make sure you have the needed table: Data Collection installed, needed module is configured and Step Function runs correctly."
+        error: You need to install Foundational Dashboards that provide account_map view.
+        default: cid_cur
+        description: Database of account_map table (from foundational dashboards)
+        global: True
 views:
   elasticache_extended_support_view:
     dependsOn:
@@ -509,13 +657,12 @@ views:
            preprocessed_elasticache_clusters
          WHERE (collection_date = max_collection_date)
       )
-      , elasticache_resources (billing_period, usage_date, payer_account_id, linked_account_id, account_name, region_code, engine, engineversion, instance_type, item_description, cacheclusterid, resource_id, original_usage_type, on_demand_rate_per_unit, tags_json, usage_amount, ext_sup_year_1_2_price, ext_sup_year_3_price) AS (
+      , elasticache_resources (billing_period, usage_date, payer_account_id, linked_account_id, region_code, engine, engineversion, instance_type, item_description, cacheclusterid, resource_id, original_usage_type, on_demand_rate_per_unit, tags_json, usage_amount, ext_sup_year_1_2_price, ext_sup_year_3_price) AS (
          SELECT
            c.bill_billing_period_start_date billing_period
          , date_trunc('day', c.line_item_usage_start_date) usage_date
          , c.bill_payer_account_id payer_account_id
          , c.line_item_usage_account_id linked_account_id
-         , accmap.account_name
          , c.product['region'] region_code
          , engine
          , engineversion
@@ -531,17 +678,15 @@ views:
          , sum(((line_item_usage_amount * round(CAST(c.pricing_public_on_demand_rate AS double), 4)) * 1.6E0)) ext_sup_year_3_price
          FROM
            (("${cur2_database}"."${cur2_table_name}" c
-         INNER JOIN sanitised_elasticache_clusters ecsu ON ((c.bill_payer_account_id = ecsu.payer_id) AND (c.line_item_usage_account_id = ecsu.accountid) AND (c.product['region'] = ecsu.region) AND (split_part(c.line_item_resource_id, ':', 7) = ecsu.cacheclusterid)))
-         INNER JOIN account_map accmap ON (c.line_item_usage_account_id = accmap.account_id))
+         INNER JOIN sanitised_elasticache_clusters ecsu ON ((c.bill_payer_account_id = ecsu.payer_id) AND (c.line_item_usage_account_id = ecsu.accountid) AND (c.product['region'] = ecsu.region) AND (split_part(c.line_item_resource_id, ':', 7) = ecsu.cacheclusterid))))
          WHERE (((c.bill_billing_period_start_date >= (date_trunc('month', current_timestamp) - INTERVAL  '4' MONTH)) AND (CAST(concat(c.billing_period, '-01') AS date) >= (date_trunc('month', current_date) - INTERVAL  '4' MONTH))) AND (c.product_servicecode = 'AmazonElastiCache') AND (c.product_product_family = 'Cache Instance') AND (c.product['cache_engine'] = 'Redis') AND (c.line_item_line_item_type IN ('DiscountedUsage', 'Usage')))
-         GROUP BY 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15
+         GROUP BY 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14
       )
       SELECT
         ecr.billing_period
       , ecr.usage_date
       , ecr.payer_account_id
       , ecr.linked_account_id
-      , ecr.account_name
       , ecr.engine
       , ecr.region_code
       , erc.engineversion
@@ -629,13 +774,12 @@ views:
              FROM preprocessed_eks_clusters_inventory
              WHERE collection_date = max_collection_date
       )
-      , eks_clusters_usage (billing_period, usage_date, payer_account_id, linked_account_id, account_name, region_code, cluster_name, k8s_version, item_description, usage_unit, resource_id, original_usage_type, tags_json, usage_amount) AS (
+      , eks_clusters_usage (billing_period, usage_date, payer_account_id, linked_account_id, region_code, cluster_name, k8s_version, item_description, usage_unit, resource_id, original_usage_type, tags_json, usage_amount) AS (
          SELECT
            c.bill_billing_period_start_date
          , date_trunc('day', c.line_item_usage_start_date)
          , c.bill_payer_account_id payer_account_id
          , c.line_item_usage_account_id linked_account_id
-         , accmap.account_name
          , c.product['region'] region_code
          , eksinv.cluster_name
          , eksinv.k8s_version
@@ -648,16 +792,14 @@ views:
          FROM
            ("${cur2_database}"."${cur2_table_name}" c
          INNER JOIN eks_clusters_inventory eksinv ON ((c.bill_payer_account_id = eksinv.payer_id) AND (c.line_item_usage_account_id = eksinv.accountid) AND (c.product['region'] = eksinv.region) AND (c.line_item_resource_id = eksinv.cluster_arn)))
-         INNER JOIN account_map accmap on c.line_item_usage_account_id = accmap.account_id
          WHERE (((c.bill_billing_period_start_date >= ("date_trunc"('month', current_timestamp) - INTERVAL  '4' MONTH)) AND (CAST(concat(c.billing_period, '-01') AS date) >= (date_trunc('month', current_date) - INTERVAL  '4' MONTH))) AND (c.product_servicecode = 'AmazonEKS') AND (c.line_item_line_item_type IN ('Usage')) AND ((c.product_product_family = 'Compute') AND (c.line_item_usage_type LIKE '%AmazonEKS-Hours:perCluster')))
-         GROUP BY 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13
+         GROUP BY 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12
       )
       SELECT
         ekscus.billing_period
       , ekscus.usage_date
       , ekscus.payer_account_id
       , ekscus.linked_account_id
-      , ekscus.account_name
       , ekscus.region_code
       , ekscus.original_usage_type
       , ekscus.k8s_version
@@ -877,13 +1019,12 @@ views:
              , engineversion
            FROM sanitised_rds_clusters
       )
-      , rds_resources (billing_period, usage_date, payer_account_id, linked_account_id, account_name, region_code, rds_type, deployment_option, engine, engineversion, instance_type_family, instance_type, item_description, vcpus, usage_unit, dbresourceidentifier, resource_id, original_deployment_option, original_usage_type, tags_json, usage_amount, vcpu_acu_hours) AS (
+      , rds_resources (billing_period, usage_date, payer_account_id, linked_account_id, region_code, rds_type, deployment_option, engine, engineversion, instance_type_family, instance_type, item_description, vcpus, usage_unit, dbresourceidentifier, resource_id, original_deployment_option, original_usage_type, tags_json, usage_amount, vcpu_acu_hours) AS (
          SELECT
            c.bill_billing_period_start_date billing_period
          , date_trunc('day', c.line_item_usage_start_date) usage_date
          , c.bill_payer_account_id payer_account_id
          , c.line_item_usage_account_id linked_account_id
-         , accmap.account_name
          , c.product['region'] region_code
          , (CASE WHEN (c.product['database_engine'] LIKE 'Aurora%') THEN 'Aurora' ELSE 'AmazonRDS' END) rds_type
          , (CASE WHEN (c.line_item_usage_type LIKE '%InstanceUsage%') THEN 'SINGLE-AZ' WHEN (c.line_item_usage_type LIKE '%Multi-AZUsage%') THEN 'MULTI-AZ' WHEN (c.line_item_usage_type LIKE '%Multi-AZClusterUsage%') THEN 'MULTI-AZ-CLUSTER' WHEN ((c.product_product_family = 'Serverless') AND (c.line_item_usage_type like '%Aurora:Serverless%Usage')) THEN 'SERVERLESS' WHEN ((c.product_product_family = 'ServerlessV2') AND (c.line_item_usage_type like '%Aurora:ServerlessV2%Usage')) THEN 'SERVERLESSV2' ELSE 'UNDEFINED (Check the usage type)' END) deployment_option
@@ -903,17 +1044,15 @@ views:
          , sum((CASE WHEN (c.pricing_unit = 'ACU-Hr') THEN c.line_item_usage_amount WHEN (c.line_item_usage_type LIKE '%Multi-AZUsage%') THEN (CAST(c.product['vcpu'] AS int) * c.line_item_usage_amount * 2) ELSE (CAST(c.product['vcpu'] AS int) * c.line_item_usage_amount) END)) vcpu_acu_hours
          FROM
            (("${cur2_database}"."${cur2_table_name}" c
-         INNER JOIN all_sanitised_rds_resources rdsu ON ((c.bill_payer_account_id = rdsu.payer_id) AND (c.line_item_usage_account_id = rdsu.accountid) AND (c.product['region'] = rdsu.region) AND (split_part(c.line_item_resource_id, ':', 7) = rdsu.dbresourceidentifier)))
-         INNER JOIN account_map accmap ON (c.line_item_usage_account_id = accmap.account_id))
+         INNER JOIN all_sanitised_rds_resources rdsu ON ((c.bill_payer_account_id = rdsu.payer_id) AND (c.line_item_usage_account_id = rdsu.accountid) AND (c.product['region'] = rdsu.region) AND (split_part(c.line_item_resource_id, ':', 7) = rdsu.dbresourceidentifier))))
          WHERE (((c.bill_billing_period_start_date >= (date_trunc('month', current_timestamp) - INTERVAL  '4' MONTH)) AND (CAST(concat(c.billing_period, '-01') AS date) >= (date_trunc('month', current_date) - INTERVAL  '4' MONTH))) AND (c.product_servicecode = 'AmazonRDS') AND (c.line_item_line_item_type IN ('DiscountedUsage', 'Usage')) AND ((c.product_product_family = 'Database Instance') OR ((c.product_product_family like 'Serverless%') AND (c.line_item_usage_type like '%Aurora:Serverless%Usage'))))
-         GROUP BY 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20
+         GROUP BY 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19
       )
       SELECT
         rdsr.billing_period
       , rdsr.usage_date
       , rdsr.payer_account_id
       , rdsr.linked_account_id
-      , rdsr.account_name
       , rdsr.region_code
       , rdsr.rds_type
       , rdsr.deployment_option
@@ -1097,13 +1236,12 @@ views:
            preprocessed_opensearch_domains
          WHERE (collection_date = max_collection_date)
       )
-      , opensearch_resources (billing_period, usage_date, payer_account_id, linked_account_id, account_name, region_code, domainidentifier, domainname, resourceid, engineversion, instance_type, instance_size, norm_factor, usage_unit, item_description, original_usage_type, tags_json, usage_amount, nihs) AS (
+      , opensearch_resources (billing_period, usage_date, payer_account_id, linked_account_id, region_code, domainidentifier, domainname, resourceid, engineversion, instance_type, instance_size, norm_factor, usage_unit, item_description, original_usage_type, tags_json, usage_amount, nihs) AS (
          SELECT
            c.bill_billing_period_start_date billing_period
          , date_trunc('day', c.line_item_usage_start_date) usage_date
          , c.bill_payer_account_id payer_account_id
          , c.line_item_usage_account_id linked_account_id
-         , accmap.account_name
          , c.product['region'] region_code
          , osu.domainidentifier
          , osu.domainname
@@ -1120,18 +1258,16 @@ views:
          , sum((isnf.normalization_factor * c.line_item_usage_amount))
          FROM
            ((("${cur2_database}"."${cur2_table_name}" c
-         INNER JOIN sanitised_opensearch_domains osu ON ((c.bill_payer_account_id = osu.payer_id) AND (c.line_item_usage_account_id = osu.accountid) AND (c.product['region'] = osu.region) AND (split_part(c.line_item_resource_id, ':', 6) = osu.domainidentifier)))
-         INNER JOIN account_map accmap ON (c.line_item_usage_account_id = accmap.account_id))
+         INNER JOIN sanitised_opensearch_domains osu ON ((c.bill_payer_account_id = osu.payer_id) AND (c.line_item_usage_account_id = osu.accountid) AND (c.product['region'] = osu.region) AND (split_part(c.line_item_resource_id, ':', 6) = osu.domainidentifier))))
          INNER JOIN instance_size_norm_factors isnf ON (regexp_extract(c.product_instance_type, '.+?\.(.+?)\.search', 1) = isnf.instance_size))
          WHERE (((c.bill_billing_period_start_date >= (date_trunc('month', current_timestamp) - INTERVAL  '4' MONTH)) AND (CAST(concat(c.billing_period, '-01') AS date) >= (date_trunc('month', current_date) - INTERVAL  '4' MONTH))) AND ((c.product_servicecode = 'AmazonES') AND (product_product_family = 'Amazon OpenSearch Service Instance') AND (line_item_operation = 'ESDomain')) AND (c.line_item_line_item_type IN ('DiscountedUsage', 'Usage')) AND (NOT (c.line_item_usage_type IN ('OpenSearchExtendedSupport'))))
-         GROUP BY 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17
+         GROUP BY 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16
       )
       SELECT
         osr.billing_period
       , osr.usage_date
       , osr.payer_account_id
       , osr.linked_account_id
-      , osr.account_name
       , osr.region_code
       , osr.domainname
       , osr.domainidentifier


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws-solutions-library-samples/cloud-intelligence-dashboards-framework/issues/1461

*Description of changes:*
Extended Support Cost Projection - moving account map join to QuickSight. Removing account map join from view queries.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
