### PR TITLE
Fix/ext supp taxonomy fields

### DIFF
--- a/changes/CHANGELOG-extended-support-cost-projection.md
+++ b/changes/CHANGELOG-extended-support-cost-projection.md
@@ -1,5 +1,20 @@
 # What's new in Extended Support Cost Projection
 
+## Extended Support Cost Projection - v5.2.1
+
+**Important:** This version updates the tagging view Athena query and the tagging view dataset definition. A forced and recursive update is required to pick up the changes.
+
+To update run these commands in your CloudShell (recommended) or other terminal:
+
+```
+python3 -m ensurepip --upgrade
+pip3 install --upgrade cid-cmd
+cid-cmd update --dashboard-id extended-support-cost-projection --force --recursive
+```
+
+- Joined `account_map` to the `extended_support_tagging_view` dataset so account-level taxonomy fields (e.g. OU columns) are carried through to the tagging dataset. This enables them to be included in the taxonomy candidate list during `cid-cmd` install/update, alongside the four resource datasets that already join `account_map`.
+- Added `line_item_usage_account_id` to the tagging Athena view so the dataset-level join has a matching key.
+
 ## Extended Support Cost Projection - v5.2.0
 
 **Important:** This version requires the data collection version 3.2.0+. Update to this version requires a forced update. Since this is a major version upgrade, the `cid-cmd` tool will ask to confirm a recursive update or not. Please make sure to confirm the recursive update by answering **yes** to continue the update process and have the view queries and datasets updated.

--- a/changes/cloud-intelligence-dashboards.rss
+++ b/changes/cloud-intelligence-dashboards.rss
@@ -5,8 +5,25 @@
     <link>https://docs.aws.amazon.com/guidance/latest/cloud-intelligence-dashboards/</link>
     <atom:link href="https://cid.workshops.aws.dev/feed/cloud-intelligence-dashboards.rss" rel="self" type="application/rss+xml"/>
     <description>The Cloud Intelligence Dashboards is an open-source framework, lovingly cultivated and maintained by a group of customer-obsessed AWSers, that gives customers the power to get high-level and granular insight into their cost and usage data. Supported by the Well-Architected framework, the dashboards can be deployed by any customer using a CloudFormation template or a command-line tool in their environment in under 30 minutes. These dashboards help you to drive financial accountability, optimize cost, track usage goals, implement best-practices for governance, and achieve operational excellence across all your organization.</description>
-    <lastBuildDate>Wed, 22 Apr 2026 12:00:00 GMT</lastBuildDate>
+    <lastBuildDate>Wed, 29 Apr 2026 12:00:00 GMT</lastBuildDate>
     <language>en-us</language>
+    <item>
+      <title>[Update] Extended Support Cost Projection - v5.2.1</title>
+      <link>
+        https://github.com/aws-solutions-library-samples/cloud-intelligence-dashboards-framework/blob/main/changes/CHANGELOG-extended-support-cost-projection.md#extended-support-cost-projection---v521
+      </link>
+      <pubDate>Wed, 29 Apr 2026 12:00:00 GMT</pubDate>
+      <category><![CDATA[Dashboard Update]]></category>
+      <guid isPermaLink="false">62a39c63-9f01-4a4a-8301-23117aee0101</guid>
+      <description>Extended Support Cost Projection - v5.2.1</description>
+      <content:encoded><![CDATA[
+<div>
+  <ul>
+    <li>Joined <code>account_map</code> to the <code>extended_support_tagging_view</code> dataset so account-level taxonomy fields (e.g. OU columns) are carried through and included in the taxonomy candidate list during <code>cid-cmd</code> install/update.</li>
+  </ul>
+</div>
+    ]]></content:encoded>
+    </item>
     <item>
       <title>[Update] Extended Support Cost Projection - v5.2.0</title>
       <link>

--- a/dashboards/extended-support-cost-projection/extended-support-cost-projection.yaml
+++ b/dashboards/extended-support-cost-projection/extended-support-cost-projection.yaml
@@ -17,7 +17,16 @@ dashboards:
     - opensearch_extended_support_view
     - elasticache_extended_support_view
     nonTaxonomyColumns:
+    - account_email_id
+    - account_id
+    - account_name
+    - account_prefix
+    - account_suffix
+    - line_item_usage_account_id
     - line_item_product_code
+    - o_u
+    - parent_account_id
+    - parent_account_name
     - tags_json
     file: ./extended-support-cost-projection-definition.yaml
     version: v5.2.0
@@ -578,26 +587,55 @@ datasets:
             Schema: ${athena_database_name}
             Name: extended_support_tagging_view
             InputColumns:
+            - Name: line_item_usage_account_id
+              Type: STRING
             - Name: line_item_product_code
               Type: STRING
             - Name: tags_json
               Type: STRING
             - Name: rows
               Type: INTEGER
+        90e1376c-d426-4481-9af2-e30d8e9a10c1:
+          RelationalTable:
+            DataSourceArn: ${athena_datasource_arn}
+            Catalog: AwsDataCatalog
+            Schema: ${account_map_database_name}
+            Name: account_map
+            InputColumns:
+            - Name: account_id
+              Type: STRING
+            - Name: account_name
+              Type: STRING
       LogicalTableMap:
         30248d27-4a3a-4350-bf1d-dd382f040c95:
           Alias: extended_support_tagging_view
+          Source:
+            PhysicalTableId: 5a574f8c-5e74-4da8-97cc-4f6802a7d360
+        56854c6e-a164-4519-9bc0-35fe9d016a25:
+          Alias: account_map
+          Source:
+            PhysicalTableId: 90e1376c-d426-4481-9af2-e30d8e9a10c1
+        dc16d610-7393-42bf-8735-29e2a1165178:
+          Alias: Intermediate Table
           DataTransforms:
           - ProjectOperation:
               ProjectedColumns:
+              - line_item_usage_account_id
               - line_item_product_code
               - tags_json
               - rows
+              - account_id
+              - account_name
           Source:
-            PhysicalTableId: 5a574f8c-5e74-4da8-97cc-4f6802a7d360
+            JoinInstruction:
+              LeftOperand: 30248d27-4a3a-4350-bf1d-dd382f040c95
+              RightOperand: 56854c6e-a164-4519-9bc0-35fe9d016a25
+              Type: LEFT
+              OnClause: '{line_item_usage_account_id} = {account_id}'
       ImportMode: SPICE
     dependsOn:
       views:
+      - account_map
       - extended_support_tagging_view
     schedules:
     - default
@@ -1306,10 +1344,11 @@ views:
     data: |-
       CREATE OR REPLACE VIEW "${athena_database_name}".extended_support_tagging_view AS
       SELECT
-        line_item_product_code
+        line_item_usage_account_id
+      , line_item_product_code
       , ${cur_tags_json} tags_json
       , count(1) rows
       FROM
         "${cur2_database}"."${cur2_table_name}" cur
       WHERE ((COALESCE(line_item_product_code, '') <> '') AND ((bill_billing_period_start_date >= (date_trunc('month', current_timestamp) - INTERVAL  '7' MONTH)) AND (CAST(concat(split_part("billing_period", '-', 1), '-', split_part("billing_period", '-', 2), '-01') AS date) >= (date_trunc('month', current_date) - INTERVAL  '7' MONTH))))
-      GROUP BY 1, 2
+      GROUP BY 1, 2, 3

--- a/dashboards/extended-support-cost-projection/extended-support-cost-projection.yaml
+++ b/dashboards/extended-support-cost-projection/extended-support-cost-projection.yaml
@@ -29,7 +29,7 @@ dashboards:
     - parent_account_name
     - tags_json
     file: ./extended-support-cost-projection-definition.yaml
-    version: v5.2.0
+    version: v5.2.1
 datasets:
   elasticache_extended_support_view:
     data:

--- a/dashboards/extended-support-cost-projection/extended-support-cost-projection.yaml
+++ b/dashboards/extended-support-cost-projection/extended-support-cost-projection.yaml
@@ -17,16 +17,8 @@ dashboards:
     - opensearch_extended_support_view
     - elasticache_extended_support_view
     nonTaxonomyColumns:
-    - account_email_id
-    - account_id
-    - account_name
-    - account_prefix
-    - account_suffix
     - line_item_usage_account_id
     - line_item_product_code
-    - o_u
-    - parent_account_id
-    - parent_account_name
     - tags_json
     file: ./extended-support-cost-projection-definition.yaml
     version: v5.2.1


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws-solutions-library-samples/cloud-intelligence-dashboards-framework/issues/1461

*Description of changes:*
fix: surface taxonomy fields on extended-support tagging view

The extended_support_tagging_view dataset wasn't joined to account_map, so its OutputColumns lacked the OU columns the other four datasets carried. The taxonomy picker intersects column names across datasets, so the missing columns collapsed the candidate list and the prompt was silently skipped.

- Project line_item_usage_account_id in the view SQL (and GROUP BY).
- Add the account_map LEFT join to the tagging view dataset, matching the pattern used by the other four datasets.
- Add account_map to dependsOn.views for the extended-support-tagging-view dataset definition.
- Bumped ext. supp. cost proj. dashboard version to 5.2.1 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
