### PR TITLE
feat(cfn): Add PermissionsBoundary to all IAM roles

### DIFF
--- a/cfn-templates/cid-cfn.yml
+++ b/cfn-templates/cid-cfn.yml
@@ -1975,6 +1975,8 @@ Resources:
             Principal:
               Service: lambda.amazonaws.com
             Action: sts:AssumeRole
+      Path: !Ref RolePath
+      PermissionsBoundary: !If [NeedPermissionsBoundary, !Ref PermissionsBoundary, !Ref 'AWS::NoValue']
       ManagedPolicyArns:
         - !Sub 'arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole'
       Policies:


### PR DESCRIPTION
Fixes #1205

## Summary
Add the missing PermissionsBoundary property to InitLambdaExecutionRole and PullAssetsLambdaRole. Also add the missing Path property to PullAssetsLambdaRole for consistency.

## Changes
The PermissionsBoundary parameter and NeedPermissionsBoundary condition already existed in the template and were applied to 5 of 7 IAM roles. This ensures all roles respect the boundary when specified, enabling deployment in environments with SCP-enforced boundary requirements.

## Testing
- Verified all 7 IAM roles now have PermissionsBoundary
- Default behavior unchanged (empty string = no boundary applied)