### PR TITLE
fix(co): Add missing rootVolume column to EBS volume schema

### DIFF
--- a/cid/builtin/core/data/queries/co/ebs_volume.json
+++ b/cid/builtin/core/data/queries/co/ebs_volume.json
@@ -222,6 +222,10 @@
                     "Type": "string"
                 },
                 {
+                    "Name": "rootVolume",
+                    "Type": "string"
+                },
+                {
                     "Name": "tags",
                     "Type": "string"
                 }


### PR DESCRIPTION
Fixes #1331

## Summary
Add the missing rootVolume column to the compute_optimizer_ebs_volume_lines Glue table schema.

## Problem
The Compute Optimizer CSV export includes a rootVolume column (column 55) between currentConfiguration_rootVolume and tags. The schema was missing this column, causing the tags column to read rootVolume boolean data instead of actual tag values.

## Fix
Added `{Name: rootVolume, Type: string}` entry before the tags entry in ebs_volume.json, aligning the schema with the actual CSV column order.