### PR TITLE
feat(terraform): Add Extended Support Cost Projection dashboard

### DIFF
--- a/terraform/cicd-deployment/README.md
+++ b/terraform/cicd-deployment/README.md
@@ -70,6 +70,7 @@ dashboards = {
   containers   = "yes"  # SCAD Containers Cost Allocation
   cora         = "yes"  # CORA Dashboard
   focus        = "yes"  # FOCUS Dashboard
+  extended_support = "yes"  # Extended Support Cost Projection
 }
 ```
 
@@ -178,6 +179,7 @@ These require a foundational dashboard to be deployed first and use the same CUR
 | Containers | `containers` | yes | SCAD Containers Cost Allocation |
 | CORA | `cora` | yes | CORA Dashboard |
 | FOCUS | `focus` | yes | FOCUS Dashboard |
+| Extended Support | `extended_support` | yes | Extended Support Cost Projection |
 
 ## Advanced Configuration
 

--- a/terraform/cicd-deployment/dashboards.tf
+++ b/terraform/cicd-deployment/dashboards.tf
@@ -116,3 +116,14 @@ module "cora_dashboard" {
   config     = local.additional_dashboards.cora
   depends_on = [module.focus_dashboard]
 }
+
+# 8. Extended Support Cost Projection Dashboard - EKS, RDS, OpenSearch, ElastiCache extended support cost analysis
+module "extended_support_dashboard" {
+  source = "./modules/cloudformation_stack"
+  providers = {
+    aws = aws.datacollection
+  }
+
+  config     = local.additional_dashboards.extended_support
+  depends_on = [module.cora_dashboard]
+}

--- a/terraform/cicd-deployment/locals.tf
+++ b/terraform/cicd-deployment/locals.tf
@@ -208,6 +208,20 @@ locals {
       dashboard_id = "cora"
       dataset_name = "cora_view"
     }
+    extended_support = {
+      enabled      = var.dashboards.extended_support == "yes"
+      stack_name   = "Extended-Support-Cost-Projection-Dashboard"
+      template_url = local.template_urls.cid_plugin
+      capabilities = local.common_capabilities
+      parameters   = { DashboardId = "extended-support-cost-projection" }
+      timeouts     = local.default_timeouts
+      tags = merge(local.common_tags, {
+        DashboardType = "Additional"
+        DashboardId   = "extended-support-cost-projection"
+      })
+      dashboard_id = "extended-support-cost-projection"
+      dataset_name = "rds_extended_support_view"
+    }
   }
 
   enabled_additional_dashboards = {

--- a/terraform/cicd-deployment/user-config.tf
+++ b/terraform/cicd-deployment/user-config.tf
@@ -88,6 +88,7 @@ variable "dashboards" {
     containers   = string
     focus        = string
     cora         = string
+    extended_support = string
   })
 
   description = "Dashboard deployment configuration - choose which dashboards to deploy"
@@ -106,6 +107,7 @@ variable "dashboards" {
     containers   = "yes"
     focus        = "yes"
     cora         = "yes"
+    extended_support = "yes"
   }
 
   validation {
@@ -126,7 +128,8 @@ variable "dashboards" {
       var.dashboards.connect == "yes",
       var.dashboards.containers == "yes",
       var.dashboards.focus == "yes",
-      var.dashboards.cora == "yes"
+      var.dashboards.cora == "yes",
+      var.dashboards.extended_support == "yes"
     ])
     error_message = "At least one dashboard must be enabled"
   }
@@ -147,7 +150,8 @@ variable "dashboards" {
         var.dashboards.connect == "yes",
         var.dashboards.containers == "yes",
         var.dashboards.focus == "yes",
-        var.dashboards.cora == "yes"
+        var.dashboards.cora == "yes",
+        var.dashboards.extended_support == "yes"
       ])
     )
     error_message = "Additional dashboards require at least one foundational dashboard (cudos_v5, cost_intelligence, or kpi) to be enabled, OR set 'allow_standalone_dashboard = true' if foundational dashboards are already deployed elsewhere."


### PR DESCRIPTION
## Summary

Adds the Extended Support Cost Projection dashboard to the Terraform module, enabling Terraform-based deployment alongside the existing 7 additional dashboards.

## Changes

- **locals.tf**: Added `extended_support` entry to `additional_dashboards` map
- **dashboards.tf**: Added `extended_support_dashboard` module block (#8 in chain)
- **user-config.tf**: Added `extended_support` toggle to variable type, default, and validations
- **README.md**: Added to quick start example and Available Dashboards table

## Details

- Dashboard ID: `extended-support-cost-projection`
- Template: `cid-plugin.yml` (same as all other additional dashboards)
- Dependencies: CUR-based views only (no Data Collection module required)
- Default: enabled (`yes`)

Closes #1488