### PR TITLE
fix(summary_view): Preserve EDP discount on Savings Plan refund rows

### DIFF
--- a/cid/builtin/core/data/queries/cid/summary_view.sql
+++ b/cid/builtin/core/data/queries/cid/summary_view.sql
@@ -71,7 +71,7 @@
       WHEN ("line_item_line_item_type" = 'DiscountedUsage') THEN "reservation_effective_cost"
       WHEN ("line_item_line_item_type" = 'RIFee') THEN ("reservation_unused_amortized_upfront_fee_for_billing_period" + "reservation_unused_recurring_fee")
       WHEN (("line_item_line_item_type" = 'Fee') AND ("reservation_reservation_a_r_n" <> '')) THEN 0
-      WHEN (("line_item_line_item_type" = 'Refund') AND ("line_item_product_code" = 'ComputeSavingsPlans')) THEN 0
+      WHEN (("line_item_line_item_type" = 'Refund') AND ("line_item_product_code" = 'ComputeSavingsPlans') AND ("savings_plan_savings_plan_a_r_n" <> '') AND (TRY("date_diff"('day', "from_iso8601_timestamp"("savings_plan_start_time"), "from_iso8601_timestamp"("savings_plan_end_time"))) <= 7)) THEN 0
       ELSE "line_item_unblended_cost"
     END) "amortized_cost"
   , sum(CASE


### PR DESCRIPTION
## Problem

PR #1112 (Jan 2025) added a filter to suppress the cosmetic artifact when an SP is returned within 7 days:

```sql
WHEN (('line_item_line_item_type' = 'Refund') AND ('line_item_product_code' = 'ComputeSavingsPlans')) THEN 0
```

This zeros **all** Refund rows on ComputeSavingsPlans, including legitimate EDP/PPA discount refunds (~$8.8K/month reported in #cid-builders by Meredith Holborn, 2026-03-28).

## Fix

Narrow the predicate to only zero refund rows that are actual within-7-day SP cancellation refunds:

```sql
WHEN (('line_item_line_item_type' = 'Refund')
      AND ('line_item_product_code' = 'ComputeSavingsPlans')
      AND ('savings_plan_savings_plan_a_r_n' <> '')
      AND (TRY(date_diff('day', from_iso8601_timestamp(savings_plan_start_time),
                                from_iso8601_timestamp(savings_plan_end_time))) <= 7))
THEN 0
```

- `savings_plan_savings_plan_a_r_n <> ''` — confirms actual SP row (EDP refunds typically have empty ARN)
- `date_diff <= 7` — matches only within-7-day cancellation refunds (Yuriy's original intent)
- `TRY()` — guards malformed/missing timestamps (falls through to safe default)

## Verification

```sql
SELECT line_item_line_item_type, line_item_product_code,
       savings_plan_savings_plan_a_r_n, savings_plan_start_time, savings_plan_end_time,
       line_item_unblended_cost
FROM cur_database.cur_table
WHERE line_item_line_item_type = 'Refund'
  AND line_item_product_code = 'ComputeSavingsPlans'
  AND bill_billing_period_start_date >= DATE '2026-02-01'
```

Rows with empty ARN or date_diff > 7 are EDP refunds that should surface in amortized_cost.

Relates-to: #1112
cc: @yuriypr @mholborn