### PR TITLE
fix: cur_proxy returns typed NULL instead of Python None for CUR2→CUR1 proxy fields

### DIFF
--- a/cid/helpers/cur_proxy.py
+++ b/cid/helpers/cur_proxy.py
@@ -539,6 +539,18 @@ class ProxyView():
                 if field.startswith(tag_type + '_'):
                     short_field_name = field[len(tag_type + '_'):]
                     return f"{tag_type}['{short_field_name}']"
+            # CUR1 fields with known CUR2 equivalents via cur1to2_mapping
+            cur2to1_mapping = {value: key for key, value in cur1to2_mapping.items()}
+            if field in cur2to1_mapping:
+                cur2_equivalent = cur2to1_mapping[field]
+                if self.cur.column_exists(cur2_equivalent):
+                    return cur2_equivalent
+                # CUR2 equivalent uses product MAP access
+                if cur2_equivalent.startswith("product["):
+                    if self.cur.column_exists('product'):
+                        return cur2_equivalent
+            # Field has no CUR2 equivalent or equivalent missing — return typed NULL
+            return empty.get(field_type.lower(), 'CAST(NULL AS varchar)')
 
 
     def column_surely_exist(self, field_to_expose):


### PR DESCRIPTION
## Summary

Fixes Issue 1 from #1498.

When building a CUR1 proxy view from CUR2 data, `get_sql_expression()` (line ~536-543 in `cid/helpers/cur_proxy.py`) returned implicit Python `None` for fields that:
- Don't have `resource_tags_` or `cost_category_` prefixes
- Aren't handled by the existing tag loop

This caused Athena errors: `Column 'none' cannot be resolved`

## Fix

Added after the tag loop:
1. Lookup in `cur1to2_mapping` for known CUR2 equivalents
2. Support for `product[]` MAP access for product-prefixed fields
3. Fallback to typed `CAST(NULL AS ...)` for fields with no equivalent

## Testing

- Deployed CID on a fresh CUR 2.0-only account (no legacy CUR)
- Before fix: `cur1_proxy` view creation fails with `Column 'none' cannot be resolved`
- After fix: `cur1_proxy` view created successfully with proper NULL values

## Related

- Fixes #1498 (Issue 1)
- Issue 2 (missing columns in Data Export template) still requires separate fix