### PR TITLE
fix(cur_proxy): Return SQL expression instead of None for CUR2→CUR1 proxy fields

### DIFF
--- a/cid/helpers/cur_proxy.py
+++ b/cid/helpers/cur_proxy.py
@@ -539,6 +539,11 @@ class ProxyView():
                 if field.startswith(tag_type + '_'):
                     short_field_name = field[len(tag_type + '_'):]
                     return f"{tag_type}['{short_field_name}']"
+            # Non-tag fields: look up the CUR1→CUR2 mapping for the SQL expression
+            if field in cur1to2_mapping:
+                return cur1to2_mapping[field]
+            # Field has no known CUR2 equivalent — return typed NULL
+            return empty.get(field_type.lower(), 'CAST(NULL AS varchar)')
 
 
     def column_surely_exist(self, field_to_expose):


### PR DESCRIPTION
## Problem

get_sql_expression() in cur_proxy.py has an incomplete code path when current_cur_version='2' and target_cur_version='1'. For non-tag fields (e.g. month, year, product_sku), the function falls through without a return, producing Python None which gets interpolated as literal 'None' in SQL.

PCA dashboard is broken for CUR 2.0-only customers.

## Fix

After the tag/cost_category loop, look up the field in cur1to2_mapping (CUR1→CUR2 SQL equivalents). If not found, return typed NULL.

Fixes #1498