### PR TITLE
fix: Add missing product['cache_engine'] dependency in ElastiCache view

### DIFF
--- a/changes/CHANGELOG-extended-support-cost-projection.md
+++ b/changes/CHANGELOG-extended-support-cost-projection.md
@@ -1,5 +1,21 @@
 # What's new in Extended Support Cost Projection
 
+## Extended Support Cost Projection - v5.2.2
+
+**Important:** This version updates the definition of the ElastiCache view for the Extended Support dashboard. A forced and recursive update is required to pick up the changes.
+
+If you have modified the Extended Support Cost Projection dashboard visuals, these changes will be overridden when the dashboard is updated. Consider backing-up the existing dashboard by creating an analysis from it if you want to keep a reference to customised visuals so you can re-apply them after the update takes place.
+
+To update run these commands in your CloudShell (recommended) or other terminal:
+
+```
+python3 -m ensurepip --upgrade
+pip3 install --upgrade cid-cmd
+cid-cmd update --dashboard-id extended-support-cost-projection --force --recursive
+```
+
+- Fixed missing `product['cache_engine']` dependency declaration in the `elasticache_extended_support_view`. This ensures CUR1 users have `product_cache_engine` included in the `cur2_proxy` MAP expression, preventing query failures when the view filters on `product['cache_engine'] = 'Redis'`.
+
 ## Extended Support Cost Projection - v5.2.1
 
 **Important:** This version updates the tagging view Athena query and the tagging view dataset definition. A forced and recursive update is required to pick up the changes.

--- a/changes/cloud-intelligence-dashboards.rss
+++ b/changes/cloud-intelligence-dashboards.rss
@@ -5,8 +5,25 @@
     <link>https://docs.aws.amazon.com/guidance/latest/cloud-intelligence-dashboards/</link>
     <atom:link href="https://cid.workshops.aws.dev/feed/cloud-intelligence-dashboards.rss" rel="self" type="application/rss+xml"/>
     <description>The Cloud Intelligence Dashboards is an open-source framework, lovingly cultivated and maintained by a group of customer-obsessed AWSers, that gives customers the power to get high-level and granular insight into their cost and usage data. Supported by the Well-Architected framework, the dashboards can be deployed by any customer using a CloudFormation template or a command-line tool in their environment in under 30 minutes. These dashboards help you to drive financial accountability, optimize cost, track usage goals, implement best-practices for governance, and achieve operational excellence across all your organization.</description>
-    <lastBuildDate>Wed, 04 Jun 2026 12:00:00 GMT</lastBuildDate>
+    <lastBuildDate>Wed, 18 Jun 2026 12:00:00 GMT</lastBuildDate>
     <language>en-us</language>
+    <item>
+      <title>[Update] Extended Support Cost Projection v5.2.2</title>
+      <link>
+        https://github.com/aws-samples/aws-cudos-framework-deployment/blob/main/changes/CHANGELOG-extended-support-cost-projection.md
+      </link>
+      <pubDate>Wed, 18 Jun 2026 12:00:00 GMT</pubDate>
+      <category><![CDATA[Dashboard Update]]></category>
+      <guid isPermaLink="false">3948f771-907f-4e4a-91d4-4f13c8a83eb2</guid>
+      <description>Extended Support Cost Projection v5.2.2</description>
+      <content:encoded><![CDATA[
+<div>
+  <ul>
+    <li><strong>ElastiCache:</strong> Fixed missing <code>product['cache_engine']</code> dependency declaration in the ElastiCache extended support view, resolving query failures for CUR1 users.</li>
+  </ul>
+</div>
+    ]]></content:encoded>
+    </item>
     <item>
       <title>[Update] cid-cmd v4.4.14</title>
       <link>

--- a/dashboards/extended-support-cost-projection/extended-support-cost-projection.yaml
+++ b/dashboards/extended-support-cost-projection/extended-support-cost-projection.yaml
@@ -21,7 +21,7 @@ dashboards:
     - line_item_product_code
     - tags_json
     file: ./extended-support-cost-projection-definition.yaml
-    version: v5.2.1
+    version: v5.2.2
 datasets:
   elasticache_extended_support_view:
     data:
@@ -649,6 +649,7 @@ views:
         - product_servicecode
         - product['region']
         - pricing_public_on_demand_rate
+        - product['cache_engine']
     data: |-
       CREATE OR REPLACE VIEW "${athena_database_name}".elasticache_extended_support_view AS
       WITH


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fixed missing `product['cache_engine']` dependency declaration in the `elasticache_extended_support_view`. This ensures CUR1 users have `product_cache_engine` included in the `cur2_proxy` MAP expression, preventing query failures when the view filters on `product['cache_engine'] = 'Redis'

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
