### PR TITLE
feat: merge tags if they are the same

### DIFF
--- a/cid/common.py
+++ b/cid/common.py
@@ -2293,6 +2293,28 @@ class Cid():
             logger.debug(f'cur.tag_fields_by_dimension = {merge_map}')
             if merge_map and selected is None:
                 keys_to_merge, merge_strategy = self._resolve_merge_config(param_name, merge_map)
+            elif merge_map:
+                # In pre-seeded/non-interactive runs selected tags are already set,
+                # so reuse merge parameters without prompting.
+                merge_strategy = get_parameters().get(f'{param_name}-merge-strategy', 'resource_first')
+
+                raw_keys = (
+                    get_parameters().get(f'{param_name}-merges')
+                    or get_parameters().get(f'{param_name}-merge-keys')
+                    or []
+                )
+                if isinstance(raw_keys, str):
+                    keys_to_merge = {k for k in raw_keys.split(',') if k}
+                else:
+                    keys_to_merge = set(raw_keys)
+
+                # Also infer merge keys from explicit merged_* selections.
+                for name in (selected or []):
+                    if isinstance(name, str) and name.startswith('merged_'):
+                        keys_to_merge.add(name[len('merged_'):])
+
+                # Keep only valid keys present in current merge candidates.
+                keys_to_merge &= set(merge_map.keys())
 
         merged_display = self._build_tag_choices(tags_and_names, keys_to_merge, merge_map)
         all_choices = sorted(list(merged_display) + list(tags_and_names))

--- a/cid/common.py
+++ b/cid/common.py
@@ -2044,6 +2044,40 @@ class Cid():
         return 'resource_tags'  # fallback
 
     @staticmethod
+    def _tag_to_name(tag: str) -> str:
+        """Convert a raw CUR tag selector into a normalised JSON key name.
+
+        Works for both CUR1 flat columns (``resource_tags_user_env``) and CUR2
+        MAP accessors (``resource_tags['user_env']``, ``tags['accountTag/Env']``).
+        The result is safe for QuickSight ``parseJson`` dot-notation: every
+        non-word character is replaced with ``_``.
+        """
+        if tag == 'line_item_iam_principal':
+            return 'iam_principal'
+        tag_name = (tag
+            .replace('resource_tags_', '')
+            .replace('cost_category_', '')
+            .replace("'user_", "'tag_")
+            .replace('accountTag/', '')
+            .replace('userAttribute/', '')
+            .replace('iamPrincipal/', '')
+            .replace("'aws_", "'tag_aws_")
+            .split("['")[-1].split("']")[0]
+        )
+        if not tag_name.startswith('tag_'):
+            if tag.startswith('cost_category'):
+                tag_name = 'cost_category_' + tag_name
+            elif "userAttribute/" in tag:
+                tag_name = 'user_attribute_tag_' + tag_name
+            elif "iamPrincipal/" in tag:
+                tag_name = 'iam_principal_tag_' + tag_name
+            elif tag.startswith('tags'):
+                tag_name = 'account_tag_' + tag_name
+            else:
+                tag_name = 'tag_' + tag_name
+        return re.sub(r'\W', '_', tag_name)
+
+    @staticmethod
     def _build_merge_sql(bare_key: str, selectors: list, strategy: str) -> str:
         """Build a ``COALESCE(NULLIF(..., ''), ...)`` SQL expression that implements
         a cross-dimension merge for *bare_key*, trying each selector in the order
@@ -2063,7 +2097,7 @@ class Cid():
             ``ARRAY[...]`` element inside ``MAP_FROM_ENTRIES``.
         """
         order = Cid._MERGE_STRATEGY_ORDER.get(strategy, Cid._MERGE_STRATEGY_ORDER['resource_first'])
-        # Sort selectors according to the chosen dimension priority
+
         def _rank(sel):
             dim = Cid._selector_dimension(sel)
             try:
@@ -2079,200 +2113,145 @@ class Cid():
         )
         return f'COALESCE(\n                        {coalesce_args}\n                    )'
 
-    def generic_tags_json(self, param_name='resource-tags', options=[], cur=None) -> str:
-        """Return an Athena SQL expression that serialises selected cost allocation
-        tags (and optional cross-dimension merges) into a JSON string column.
+    @staticmethod
+    def _load_selected_tags(param_name: str):
+        """Return the previously stored tag selection for *param_name*, or ``None``.
 
-        When *cur* is supplied and is a CUR2 instance the method will detect tag
-        keys that exist in more than one dimension (e.g. both ``resource_tags`` and
-        ``tags['accountTag/...']``) and — after confirming with the user — produce a
-        single ``COALESCE``-based entry in the JSON map for each merged key instead
-        of separate per-dimension entries.
-
-        The resulting SQL is substituted for ``${cur_tags_json}`` in the core view
-        templates (``summary_view``, ``hourly_view``, ``resource_view``).
+        Checks both the hyphenated and underscored variants of the key so that
+        CLI flags (``--resource-tags``) and programmatic callers
+        (``resource_tags=...``) both resolve correctly.  A comma-separated string
+        is split into a list; an existing list is returned as-is.
         """
-        def _tag_to_name(tag):
-            if tag == 'line_item_iam_principal':
-                return 'iam_principal'
-            tag_name = (tag
-                .replace('resource_tags_', '')
-                .replace('cost_category_', '')
-                .replace("'user_","'tag_")
-                .replace('accountTag/', '')
-                .replace('userAttribute/', '')
-                .replace('iamPrincipal/', '')
-                .replace("'aws_","'tag_aws_")
-                .split("['")[-1].split("']")[0]
-            )
-            if not tag_name.startswith('tag_'):
-                if tag.startswith('cost_category'):
-                    tag_name = 'cost_category_' + tag_name
-                elif "userAttribute/" in tag:
-                    tag_name = 'user_attribute_tag_' + tag_name
-                elif "iamPrincipal/" in tag:
-                    tag_name = 'iam_principal_tag_' + tag_name
-                elif tag.startswith('tags'):
-                    tag_name = 'account_tag_' + tag_name
-                else:
-                    tag_name = 'tag_' + tag_name
-            return re.sub(r'\W', '_', tag_name)
+        value = (
+            get_parameters().get(param_name)
+            or get_parameters().get(param_name.replace('_', '-'))
+        )
+        if isinstance(value, str):
+            return [t for t in value.split(',') if t]
+        return value  # list or None
 
-        # ------------------------------------------------------------------
-        # Step 1: Build the full selector → normalised-name mapping
-        # ------------------------------------------------------------------
-        resource_tags = get_parameters().get(param_name, None) or get_parameters().get(param_name.replace('_', '-'), None)
-        tags_and_names = {_tag_to_name(tag): tag for tag in sorted(options)}
-        logger.info(f'tags_and_names = {tags_and_names}')
-        logger.info(f'resource_tags = {resource_tags}')
-        if isinstance(resource_tags, str):
-            resource_tags = [tag for tag in resource_tags.split(',') if tag]
+    def _resolve_merge_config(self, param_name: str, merge_map: dict) -> tuple:
+        """Determine which tag keys to merge and which strategy to use.
 
-        # ------------------------------------------------------------------
-        # Step 2: Cross-dimension merge detection (CUR2 only)
-        # ------------------------------------------------------------------
-        # merge_map: bare_key -> list[selector]  (only keys with 2+ dimensions)
-        # merge_strategy: str  ('resource_first' | 'account_first')
-        # keys_to_merge: set of bare_keys the user has chosen to merge
-        merge_map = {}
-        merge_strategy = 'resource_first'
-        keys_to_merge: set = set()
+        Reads persisted choices first; if none exist and the session is
+        interactive, prompts the user and persists their answers for future
+        ``cid update`` runs.
 
-        cross_dim_cache_key = f'_cross_dim_merge_{param_name}'
+        Args:
+            param_name: The parameter namespace (e.g. ``'resource-tags'``).
+            merge_map:  ``{bare_key: [selectors]}`` from
+                        ``cur.tag_fields_by_dimension``.
 
-        if cur is not None and getattr(cur, 'version', None) == '2':
-            merge_map = cur.tag_fields_by_dimension  # dict: bare_key -> [selectors]
+        Returns:
+            ``(keys_to_merge: set[str], strategy: str)``
+        """
+        # --- try cache first ---
+        cached_keys = get_parameters().get(f'{param_name}-merges')
+        cached_strategy = get_parameters().get(f'{param_name}-merge-strategy')
+        if cached_keys is not None:
+            keys = set(cached_keys.split(',')) if isinstance(cached_keys, str) else set(cached_keys)
+            logger.info(f'Using cached merge choices: keys={keys}, strategy={cached_strategy}')
+            return keys, cached_strategy or 'resource_first'
 
-            if merge_map and resource_tags is None:
-                # Retrieve previously persisted merge choices if available
-                cached = get_parameters().get(f'{param_name}-merges', None)
-                cached_strategy = get_parameters().get(f'{param_name}-merge-strategy', None)
+        # --- non-interactive: skip merging ---
+        if not utils.isatty():
+            logger.info('Non-interactive mode: skipping cross-dimension tag merge prompts.')
+            return set(), 'resource_first'
 
-                if cached is not None:
-                    keys_to_merge = set(cached.split(',')) if isinstance(cached, str) else set(cached)
-                    merge_strategy = cached_strategy or 'resource_first'
-                    logger.info(f'Using cached merge choices: keys={keys_to_merge}, strategy={merge_strategy}')
-                elif utils.isatty():
-                    # Display cross-dimension tags to the user
-                    cid_print('\n<BOLD>Tags found in multiple dimensions (merge candidates):<END>')
-                    dim_labels = {
-                        'resource_tags':       'resource tag',
-                        'tags_account':        'account tag',
-                        'tags_iam_principal':  'IAM principal tag',
-                        'tags_user_attribute': 'user attribute tag',
-                        'cost_category':       'cost category',
-                    }
-                    max_key_len = max(len(k) for k in merge_map) if merge_map else 0
-                    for bare_key, selectors in sorted(merge_map.items()):
-                        dims = ', '.join(dim_labels.get(self._selector_dimension(s), s) for s in selectors)
-                        cid_print(f'  <BOLD>{bare_key:<{max_key_len}}<END>  ->  {dims}')
-                    cid_print('')
+        # --- interactive: display candidates and prompt ---
+        dim_labels = {
+            'resource_tags':       'resource tag',
+            'tags_account':        'account tag',
+            'tags_iam_principal':  'IAM principal tag',
+            'tags_user_attribute': 'user attribute tag',
+            'cost_category':       'cost category',
+        }
+        cid_print('\n<BOLD>Tags found in multiple dimensions (merge candidates):<END>')
+        max_key_len = max(len(k) for k in merge_map)
+        for bare_key, selectors in sorted(merge_map.items()):
+            dims = ', '.join(dim_labels.get(self._selector_dimension(s), s) for s in selectors)
+            cid_print(f'  <BOLD>{bare_key:<{max_key_len}}<END>  ->  {dims}')
+        cid_print('')
 
-                    # Ask whether to apply a global merge strategy
-                    use_merge = get_yesno_parameter(
-                        f'{param_name}-use-merge',
-                        message='Merge tags that share the same key across multiple dimensions into a single field?',
-                        default='yes',
-                    )
+        use_merge = get_yesno_parameter(
+            f'{param_name}-use-merge',
+            message='Merge tags that share the same key across multiple dimensions into a single field?',
+            default='yes',
+        )
 
-                    if use_merge:
-                        # Global strategy choice
-                        merge_strategy = get_parameter(
-                            f'{param_name}-merge-strategy',
-                            message='Global merge strategy — which dimension takes priority when a tag exists in multiple dimensions?',
-                            choices=[
-                                'resource_first',
-                                'account_first',
-                            ],
-                            default='resource_first',
-                        )
+        if not use_merge:
+            set_parameters({f'{param_name}-merges': '', f'{param_name}-merge-strategy': 'resource_first'})
+            return set(), 'resource_first'
 
-                        # Which keys to merge
-                        chosen_merge_keys = get_parameter(
-                            f'{param_name}-merge-keys',
-                            message='Select which cross-dimension tags to merge (merged field will be named merged_<key>)',
-                            multi=True,
-                            choices=sorted(merge_map.keys()),
-                            default=sorted(merge_map.keys()),
-                        )
-                        keys_to_merge = set(chosen_merge_keys)
+        strategy = get_parameter(
+            f'{param_name}-merge-strategy',
+            message='Global merge strategy — which dimension takes priority when a tag exists in multiple dimensions?',
+            choices=['resource_first', 'account_first'],
+            default='resource_first',
+        )
+        chosen_keys = get_parameter(
+            f'{param_name}-merge-keys',
+            message='Select which cross-dimension tags to merge (merged field will be named merged_<key>)',
+            multi=True,
+            choices=sorted(merge_map.keys()),
+            default=sorted(merge_map.keys()),
+        )
+        keys_to_merge = set(chosen_keys)
+        set_parameters({
+            f'{param_name}-merges': ','.join(sorted(keys_to_merge)),
+            f'{param_name}-merge-strategy': strategy,
+        })
+        return keys_to_merge, strategy
 
-                        # Persist choices so cid update doesn't re-prompt
-                        set_parameters({
-                            f'{param_name}-merges': ','.join(sorted(keys_to_merge)),
-                            f'{param_name}-merge-strategy': merge_strategy,
-                        })
-                    else:
-                        # User opted out — persist empty to avoid re-prompting
-                        set_parameters({
-                            f'{param_name}-merges': '',
-                            f'{param_name}-merge-strategy': 'resource_first',
-                        })
-                else:
-                    logger.info('Non-interactive mode: skipping cross-dimension tag merge prompts.')
+    @staticmethod
+    def _build_tag_choices(tags_and_names: dict, keys_to_merge: set, merge_map: dict) -> dict:
+        """Build merged display options for selected cross-dimension keys.
 
-        # ------------------------------------------------------------------
-        # Step 3: Build the choice list shown to the user
-        #
-        # For keys that will be merged we show a single "merged_<key>" entry
-        # in the tag selector; the individual per-dimension entries are hidden
-        # so the user doesn't accidentally select conflicting variants.
-        # ------------------------------------------------------------------
-        merged_display: dict = {}        # normalised_name -> (bare_key, [selectors])
-        passthrough_names: dict = {}     # normalised_name -> selector  (non-merged, as today)
+        For every tag whose bare key is in *keys_to_merge* a single
+        ``merged_<key>`` entry is created in *merged_display*.
+        Individual per-dimension entries are kept in *passthrough_names* so
+        users can still select all original tags in addition to merged options.
 
-        for norm_name, selector in tags_and_names.items():
-            # Determine the bare key for this selector
-            bare = re.sub(r'\W', '_', selector.split("['")[-1].split("']")[0]
-                          .replace('accountTag/', '')
-                          .replace('userAttribute/', '')
-                          .replace('iamPrincipal/', '')
-                          .replace('user_', '', 1)
-                          ) if "[''" not in selector else norm_name
+        Args:
+            tags_and_names: ``{normalised_name: selector}`` for all available tags.
+            keys_to_merge:  Bare keys the user has chosen to merge.
+            merge_map:      ``{bare_key: [selectors]}`` from
+                            ``cur.tag_fields_by_dimension``.
 
-            if bare in keys_to_merge and bare in merge_map:
-                merged_key = f'merged_{bare}'
-                if merged_key not in merged_display:
-                    merged_display[merged_key] = (bare, merge_map[bare])
-                # Don't add individual dimension entries for this key
-            else:
-                passthrough_names[norm_name] = selector
+        Returns:
+            *merged_display* ``{merged_<key>: (bare_key, [selectors])}``
+        """
+        merged_display: dict = {
+            f'merged_{bare_key}': (bare_key, selectors)
+            for bare_key, selectors in merge_map.items()
+            if bare_key in keys_to_merge
+        }
+        return merged_display
 
-        # Combined choices: merged entries + normal entries
-        all_choices = sorted(list(merged_display.keys()) + list(passthrough_names.keys()))
+    def _build_tags_json_sql(
+        self,
+        selected_tags: list,
+        merged_display: dict,
+        tags_and_names: dict,
+        merge_strategy: str,
+    ) -> str:
+        """Render the final ``json_format(CAST(MAP_FROM_ENTRIES(ARRAY[...])))`` SQL.
 
-        # ------------------------------------------------------------------
-        # Step 4: Prompt the user to select which tags to include
-        # ------------------------------------------------------------------
-        if resource_tags is None:
-            resource_tags = get_parameter(
-                param_name,
-                message='Select Cost Allocation Tags to be added to datasets (WARNING: this can affect performance. Choose only the strict minimum)',
-                multi=True,
-                choices=all_choices,
-                default=resource_tags or [],
-            )
+        Each entry in *selected_tags* becomes one element of the Athena MAP:
+        - Tags in *merged_display* expand to a ``COALESCE(NULLIF(...), ...)``
+          expression covering all their dimensions.
+        - All other tags emit a plain ``selector`` reference.
 
-        if not resource_tags:
-            return "'{}'"
-
-        logger.debug(f'selected_tag_names = {resource_tags}')
-
-        # ------------------------------------------------------------------
-        # Step 5: Build the SQL ARRAY entries
-        # ------------------------------------------------------------------
-        pattern = r"\W"
+        Returns ``'{}'`` (literal empty JSON) if no entries can be rendered.
+        """
         array_entries = []
-        for name in resource_tags:
-            safe_name = re.sub(pattern, '_', name)
+        for name in selected_tags:
+            safe_name = re.sub(r'\W', '_', name)
             if name in merged_display:
-                # Cross-dimension merge: emit a COALESCE(NULLIF(...), ...) expression
                 bare_key, selectors = merged_display[name]
-                merge_expr = self._build_merge_sql(bare_key, selectors, merge_strategy)
-                array_entries.append(f"('{safe_name}', {merge_expr})")
+                array_entries.append(f"('{safe_name}', {self._build_merge_sql(bare_key, selectors, merge_strategy)})")
             else:
-                # Normal single-dimension tag
-                selector = passthrough_names.get(name) or tags_and_names.get(name)
+                selector = tags_and_names.get(name)
                 if selector:
                     array_entries.append(f"('{safe_name}', {selector})")
 
@@ -2280,7 +2259,7 @@ class Cid():
             return "'{}'"
 
         array = ',\n                        '.join(array_entries)
-        res = f'''
+        return f'''
             json_format(
                 CAST (
                     MAP_FROM_ENTRIES (
@@ -2291,6 +2270,47 @@ class Cid():
                 AS JSON)
             )
         '''
+
+    def generic_tags_json(self, param_name='resource-tags', options=[], cur=None) -> str:
+        """Return an Athena SQL expression that serialises selected cost allocation
+        tags into a JSON string column, substituted for ``${cur_tags_json}`` in the
+        core view templates (``summary_view``, ``hourly_view``, ``resource_view``).
+
+        When *cur* is a CUR2 instance, tag keys that exist in more than one
+        dimension are detected and — after confirming with the user — an
+        additional ``COALESCE``-based ``merged_<key>`` entry can be added while
+        keeping separate per-dimension entries available.
+        """
+        tags_and_names = {self._tag_to_name(tag): tag for tag in sorted(options)}
+        logger.info(f'tags_and_names = {tags_and_names}')
+
+        selected = self._load_selected_tags(param_name)
+        logger.info(f'pre-loaded selected tags = {selected}')
+
+        merge_map, keys_to_merge, merge_strategy = {}, set(), 'resource_first'
+        if cur is not None and getattr(cur, 'version', None) == '2':
+            merge_map = cur.tag_fields_by_dimension
+            logger.debug(f'cur.tag_fields_by_dimension = {merge_map}')
+            if merge_map and selected is None:
+                keys_to_merge, merge_strategy = self._resolve_merge_config(param_name, merge_map)
+
+        merged_display = self._build_tag_choices(tags_and_names, keys_to_merge, merge_map)
+        all_choices = sorted(list(merged_display) + list(tags_and_names))
+
+        if selected is None:
+            selected = get_parameter(
+                param_name,
+                message='Select Cost Allocation Tags to be added to datasets (WARNING: this can affect performance. Choose only the strict minimum)',
+                multi=True,
+                choices=all_choices,
+                default=[],
+            )
+
+        if not selected:
+            return "'{}'"
+
+        logger.debug(f'selected_tag_names = {selected}')
+        res = self._build_tags_json_sql(selected, merged_display, tags_and_names, merge_strategy)
         logger.trace(f'cur_tags_json = {res}')
         return res
 

--- a/cid/common.py
+++ b/cid/common.py
@@ -2018,9 +2018,80 @@ class Cid():
         self.glue.create_or_update_crawler(crawler_definition=compiled_definition)
 
 
-    def generic_tags_json(self, param_name='resource-tags', options=[]) -> str:
-        ''' returns an sql for json tag
-        '''
+    # --------------------------------------------------------------------------
+    # Dimension ordering used when building COALESCE expressions for tag merges
+    # --------------------------------------------------------------------------
+    _MERGE_STRATEGY_ORDER = {
+        'resource_first':       ['resource_tags', 'tags_iam_principal', 'tags_user_attribute', 'cost_category', 'tags_account'],
+        'account_first':        ['tags_account', 'resource_tags', 'tags_iam_principal', 'tags_user_attribute', 'cost_category'],
+    }
+
+    @staticmethod
+    def _selector_dimension(selector: str) -> str:
+        """Return a canonical dimension label for a CUR2 tag selector string."""
+        if selector == 'line_item_iam_principal':
+            return 'tags_iam_principal'
+        if selector.startswith('resource_tags'):
+            return 'resource_tags'
+        if selector.startswith('cost_category'):
+            return 'cost_category'
+        if "accountTag/" in selector:
+            return 'tags_account'
+        if "iamPrincipal/" in selector:
+            return 'tags_iam_principal'
+        if "userAttribute/" in selector:
+            return 'tags_user_attribute'
+        return 'resource_tags'  # fallback
+
+    @staticmethod
+    def _build_merge_sql(bare_key: str, selectors: list, strategy: str) -> str:
+        """Build a ``COALESCE(NULLIF(..., ''), ...)`` SQL expression that implements
+        a cross-dimension merge for *bare_key*, trying each selector in the order
+        dictated by *strategy*.
+
+        ``NULLIF(..., '')`` is used rather than plain ``COALESCE`` because Athena MAP
+        element accessors return an empty string — not ``NULL`` — for missing keys.
+
+        Args:
+            bare_key:  The normalised tag key (used only for logging).
+            selectors: All discovered selectors for this key (e.g.
+                       ``["resource_tags['user_env']", "tags['accountTag/env']"]``).
+            strategy:  One of ``'resource_first'``, ``'account_first'``.
+
+        Returns:
+            A multi-line SQL string suitable for embedding directly in an
+            ``ARRAY[...]`` element inside ``MAP_FROM_ENTRIES``.
+        """
+        order = Cid._MERGE_STRATEGY_ORDER.get(strategy, Cid._MERGE_STRATEGY_ORDER['resource_first'])
+        # Sort selectors according to the chosen dimension priority
+        def _rank(sel):
+            dim = Cid._selector_dimension(sel)
+            try:
+                return order.index(dim)
+            except ValueError:
+                return len(order)
+
+        ordered = sorted(selectors, key=_rank)
+        logger.debug(f'merge order for "{bare_key}": {[Cid._selector_dimension(s) for s in ordered]}')
+
+        coalesce_args = ',\n                        '.join(
+            f"NULLIF({sel}, '')" for sel in ordered
+        )
+        return f'COALESCE(\n                        {coalesce_args}\n                    )'
+
+    def generic_tags_json(self, param_name='resource-tags', options=[], cur=None) -> str:
+        """Return an Athena SQL expression that serialises selected cost allocation
+        tags (and optional cross-dimension merges) into a JSON string column.
+
+        When *cur* is supplied and is a CUR2 instance the method will detect tag
+        keys that exist in more than one dimension (e.g. both ``resource_tags`` and
+        ``tags['accountTag/...']``) and — after confirming with the user — produce a
+        single ``COALESCE``-based entry in the JSON map for each merged key instead
+        of separate per-dimension entries.
+
+        The resulting SQL is substituted for ``${cur_tags_json}`` in the core view
+        templates (``summary_view``, ``hourly_view``, ``resource_view``).
+        """
         def _tag_to_name(tag):
             if tag == 'line_item_iam_principal':
                 return 'iam_principal'
@@ -2047,30 +2118,168 @@ class Cid():
                     tag_name = 'tag_' + tag_name
             return re.sub(r'\W', '_', tag_name)
 
+        # ------------------------------------------------------------------
+        # Step 1: Build the full selector → normalised-name mapping
+        # ------------------------------------------------------------------
         resource_tags = get_parameters().get(param_name, None) or get_parameters().get(param_name.replace('_', '-'), None)
-        tags_and_names = {_tag_to_name(tag):tag  for tag in sorted(options)}
+        tags_and_names = {_tag_to_name(tag): tag for tag in sorted(options)}
         logger.info(f'tags_and_names = {tags_and_names}')
         logger.info(f'resource_tags = {resource_tags}')
         if isinstance(resource_tags, str):
             resource_tags = [tag for tag in resource_tags.split(',') if tag]
+
+        # ------------------------------------------------------------------
+        # Step 2: Cross-dimension merge detection (CUR2 only)
+        # ------------------------------------------------------------------
+        # merge_map: bare_key -> list[selector]  (only keys with 2+ dimensions)
+        # merge_strategy: str  ('resource_first' | 'account_first')
+        # keys_to_merge: set of bare_keys the user has chosen to merge
+        merge_map = {}
+        merge_strategy = 'resource_first'
+        keys_to_merge: set = set()
+
+        cross_dim_cache_key = f'_cross_dim_merge_{param_name}'
+
+        if cur is not None and getattr(cur, 'version', None) == '2':
+            merge_map = cur.tag_fields_by_dimension  # dict: bare_key -> [selectors]
+
+            if merge_map and resource_tags is None:
+                # Retrieve previously persisted merge choices if available
+                cached = get_parameters().get(f'{param_name}-merges', None)
+                cached_strategy = get_parameters().get(f'{param_name}-merge-strategy', None)
+
+                if cached is not None:
+                    keys_to_merge = set(cached.split(',')) if isinstance(cached, str) else set(cached)
+                    merge_strategy = cached_strategy or 'resource_first'
+                    logger.info(f'Using cached merge choices: keys={keys_to_merge}, strategy={merge_strategy}')
+                elif utils.isatty():
+                    # Display cross-dimension tags to the user
+                    cid_print('\n<BOLD>Tags found in multiple dimensions (merge candidates):<END>')
+                    dim_labels = {
+                        'resource_tags':       'resource tag',
+                        'tags_account':        'account tag',
+                        'tags_iam_principal':  'IAM principal tag',
+                        'tags_user_attribute': 'user attribute tag',
+                        'cost_category':       'cost category',
+                    }
+                    max_key_len = max(len(k) for k in merge_map) if merge_map else 0
+                    for bare_key, selectors in sorted(merge_map.items()):
+                        dims = ', '.join(dim_labels.get(self._selector_dimension(s), s) for s in selectors)
+                        cid_print(f'  <BOLD>{bare_key:<{max_key_len}}<END>  ->  {dims}')
+                    cid_print('')
+
+                    # Ask whether to apply a global merge strategy
+                    use_merge = get_yesno_parameter(
+                        f'{param_name}-use-merge',
+                        message='Merge tags that share the same key across multiple dimensions into a single field?',
+                        default='yes',
+                    )
+
+                    if use_merge:
+                        # Global strategy choice
+                        merge_strategy = get_parameter(
+                            f'{param_name}-merge-strategy',
+                            message='Global merge strategy — which dimension takes priority when a tag exists in multiple dimensions?',
+                            choices=[
+                                'resource_first',
+                                'account_first',
+                            ],
+                            default='resource_first',
+                        )
+
+                        # Which keys to merge
+                        chosen_merge_keys = get_parameter(
+                            f'{param_name}-merge-keys',
+                            message='Select which cross-dimension tags to merge (merged field will be named merged_<key>)',
+                            multi=True,
+                            choices=sorted(merge_map.keys()),
+                            default=sorted(merge_map.keys()),
+                        )
+                        keys_to_merge = set(chosen_merge_keys)
+
+                        # Persist choices so cid update doesn't re-prompt
+                        set_parameters({
+                            f'{param_name}-merges': ','.join(sorted(keys_to_merge)),
+                            f'{param_name}-merge-strategy': merge_strategy,
+                        })
+                    else:
+                        # User opted out — persist empty to avoid re-prompting
+                        set_parameters({
+                            f'{param_name}-merges': '',
+                            f'{param_name}-merge-strategy': 'resource_first',
+                        })
+                else:
+                    logger.info('Non-interactive mode: skipping cross-dimension tag merge prompts.')
+
+        # ------------------------------------------------------------------
+        # Step 3: Build the choice list shown to the user
+        #
+        # For keys that will be merged we show a single "merged_<key>" entry
+        # in the tag selector; the individual per-dimension entries are hidden
+        # so the user doesn't accidentally select conflicting variants.
+        # ------------------------------------------------------------------
+        merged_display: dict = {}        # normalised_name -> (bare_key, [selectors])
+        passthrough_names: dict = {}     # normalised_name -> selector  (non-merged, as today)
+
+        for norm_name, selector in tags_and_names.items():
+            # Determine the bare key for this selector
+            bare = re.sub(r'\W', '_', selector.split("['")[-1].split("']")[0]
+                          .replace('accountTag/', '')
+                          .replace('userAttribute/', '')
+                          .replace('iamPrincipal/', '')
+                          .replace('user_', '', 1)
+                          ) if "[''" not in selector else norm_name
+
+            if bare in keys_to_merge and bare in merge_map:
+                merged_key = f'merged_{bare}'
+                if merged_key not in merged_display:
+                    merged_display[merged_key] = (bare, merge_map[bare])
+                # Don't add individual dimension entries for this key
+            else:
+                passthrough_names[norm_name] = selector
+
+        # Combined choices: merged entries + normal entries
+        all_choices = sorted(list(merged_display.keys()) + list(passthrough_names.keys()))
+
+        # ------------------------------------------------------------------
+        # Step 4: Prompt the user to select which tags to include
+        # ------------------------------------------------------------------
         if resource_tags is None:
             resource_tags = get_parameter(
                 param_name,
-                message='Select Cost Allocation Tags to be added to datasets(WARNING: this can affect performance. Choose only the strict minimum)',
+                message='Select Cost Allocation Tags to be added to datasets (WARNING: this can affect performance. Choose only the strict minimum)',
                 multi=True,
-                choices=sorted(list(set(tags_and_names.keys()))),
+                choices=all_choices,
                 default=resource_tags or [],
             )
 
         if not resource_tags:
             return "'{}'"
+
         logger.debug(f'selected_tag_names = {resource_tags}')
+
+        # ------------------------------------------------------------------
+        # Step 5: Build the SQL ARRAY entries
+        # ------------------------------------------------------------------
         pattern = r"\W"
-        array = ',\n                        '.join(
-            # replace all special characters with _ to allow QS read from this json (QS parseJson does not like special characters)
-            [f"""('{re.sub(pattern, "_", name)}', {tags_and_names[name]})"""
-            for name in resource_tags]
-        )
+        array_entries = []
+        for name in resource_tags:
+            safe_name = re.sub(pattern, '_', name)
+            if name in merged_display:
+                # Cross-dimension merge: emit a COALESCE(NULLIF(...), ...) expression
+                bare_key, selectors = merged_display[name]
+                merge_expr = self._build_merge_sql(bare_key, selectors, merge_strategy)
+                array_entries.append(f"('{safe_name}', {merge_expr})")
+            else:
+                # Normal single-dimension tag
+                selector = passthrough_names.get(name) or tags_and_names.get(name)
+                if selector:
+                    array_entries.append(f"('{safe_name}', {selector})")
+
+        if not array_entries:
+            return "'{}'"
+
+        array = ',\n                        '.join(array_entries)
         res = f'''
             json_format(
                 CAST (
@@ -2089,6 +2298,7 @@ class Cid():
         return self.generic_tags_json(
             param_name='resource-tags',
             options=cur.tag_and_cost_category_fields,
+            cur=cur,
         )
 
     def get_view_query(self, view_name: str) -> str:

--- a/cid/helpers/cur.py
+++ b/cid/helpers/cur.py
@@ -308,6 +308,59 @@ class AbstractCUR(CidBase):
         else:
             raise NotImplemented('cur version not known')
 
+    @property
+    def tag_fields_by_dimension(self) -> dict:
+        """Returns a dict mapping bare tag key -> list of selectors found across different dimensions.
+
+        Only populated for CUR2.  Only keys that appear in **two or more** dimensions are returned,
+        making this the authoritative list of cross-dimension merge candidates.
+
+        Example return value::
+
+            {
+                'environment': [
+                    "resource_tags['user_environment']",
+                    "tags['accountTag/environment']",
+                ],
+                'cost_center': [
+                    "tags['accountTag/cost_center']",
+                    "tags['iamPrincipal/cost_center']",
+                ],
+            }
+
+        The bare key is extracted by stripping the dimension-specific prefix from each selector,
+        using the same rules as ``_tag_to_name()`` in ``common.py`` but without adding any
+        output prefix — so the result is purely the user-facing tag key name (special characters
+        normalised to ``_``).
+        """
+        if self.version != '2':
+            return {}
+
+        import re
+
+        def _bare_key(selector: str) -> str:
+            """Strip dimension prefix to get the bare, normalised tag key."""
+            if selector == 'line_item_iam_principal':
+                return 'iam_principal'
+            # Extract the key part from MAP accessor notation: foo['bar'] -> 'bar'
+            key = selector.split("['")[-1].split("']")[0]
+            # Strip dimension prefixes
+            for prefix in ('accountTag/', 'userAttribute/', 'iamPrincipal/', 'user_'):
+                if key.startswith(prefix):
+                    key = key[len(prefix):]
+                    break
+            # Normalise non-word characters to underscore (mirrors QS key sanitisation)
+            return re.sub(r'\W', '_', key)
+
+        # Bucket every discovered selector by its bare key
+        by_key: dict = {}
+        for selector in self.tag_and_cost_category_fields:
+            key = _bare_key(selector)
+            by_key.setdefault(key, []).append(selector)
+
+        # Keep only keys that appear in more than one dimension
+        return {key: selectors for key, selectors in by_key.items() if len(selectors) > 1}
+
 
 class CUR(AbstractCUR):
     """This Class represents CUR table (1 or 2 versions)"""

--- a/cid/helpers/cur.py
+++ b/cid/helpers/cur.py
@@ -361,6 +361,61 @@ class AbstractCUR(CidBase):
         # Keep only keys that appear in more than one dimension
         return {key: selectors for key, selectors in by_key.items() if len(selectors) > 1}
 
+    @property
+    def tag_fields_by_dimension(self) -> dict:
+        """Returns a dict mapping bare tag key -> list of selectors found across different dimensions.
+
+        Only populated for CUR2.  Only keys that appear in **two or more** dimensions are returned,
+        making this the authoritative list of cross-dimension merge candidates.
+
+        Example return value::
+
+            {
+                'environment': [
+                    "resource_tags['user_environment']",
+                    "tags['accountTag/environment']",
+                ],
+                'cost_center': [
+                    "tags['accountTag/cost_center']",
+                    "tags['iamPrincipal/cost_center']",
+                ],
+            }
+
+        The bare key is extracted by stripping the dimension-specific prefix from each selector,
+        using the same rules as ``_tag_to_name()`` in ``common.py`` but without adding any
+        output prefix — so the result is purely the user-facing tag key name (special characters
+        normalised to ``_``).
+        """
+        if self.version != '2':
+            return {}
+
+        import re
+
+        def _bare_key(selector: str) -> str:
+            """Strip dimension prefix to get the bare, normalised tag key."""
+            if selector == 'line_item_iam_principal':
+                return 'iam_principal'
+            # Extract the key part from MAP accessor notation: foo['bar'] -> 'bar'
+            key = selector.split("['")[-1].split("']")[0]
+            # Strip dimension prefixes
+            for prefix in ('accountTag/', 'userAttribute/', 'iamPrincipal/', 'user_'):
+                if key.startswith(prefix):
+                    key = key[len(prefix):]
+                    # Convert CamelCase/PascalCase to snake_case
+                    key = re.sub(r'(?<!^)(?=[A-Z])', '_', key).lower()
+                    break
+            # Normalise non-word characters to underscore (mirrors QS key sanitisation)
+            return re.sub(r'\W', '_', key)
+
+        # Bucket every discovered selector by its bare key
+        by_key: dict = {}
+        for selector in self.tag_and_cost_category_fields:
+            key = _bare_key(selector)
+            by_key.setdefault(key, []).append(selector)
+
+        # Keep only keys that appear in more than one dimension
+        return {key: selectors for key, selectors in by_key.items() if len(selectors) > 1}
+
 
 class CUR(AbstractCUR):
     """This Class represents CUR table (1 or 2 versions)"""

--- a/cid/test/python/test_tag_merging.py
+++ b/cid/test/python/test_tag_merging.py
@@ -1,0 +1,215 @@
+"""Unit tests for cross-dimension tag merging.
+
+These tests import and exercise the *real* production classes:
+- ``AbstractCUR.tag_fields_by_dimension``  (cid/helpers/cur.py)
+- ``Cid._selector_dimension``              (cid/common.py)
+- ``Cid._build_merge_sql``                 (cid/common.py)
+- ``Cid.generic_tags_json``                (cid/common.py)
+
+No AWS credentials or live Athena connections are required; both classes are
+instantiated via lightweight stubs that only satisfy the specific attributes
+exercised by the code under test.
+"""
+import pytest
+
+# ---------------------------------------------------------------------------
+# Helpers: minimal stubs that let us instantiate real classes without AWS
+# ---------------------------------------------------------------------------
+
+def _make_cur(selectors, version='2'):
+    """Return a real ``AbstractCUR`` subclass instance with
+    ``tag_and_cost_category_fields`` pre-loaded from *selectors* and
+    ``version`` fixed to *version*.  No Athena/Glue clients needed.
+    """
+    from cid.helpers.cur import AbstractCUR
+
+    class StubCUR(AbstractCUR):
+        # AbstractCUR requires these two abstract-ish methods
+        def ensure_column(self, column, column_type=None):
+            pass
+
+        @property
+        def metadata(self):
+            # 'bill_payer_account_name' being present triggers version == '2'
+            cols = [{'Name': 'bill_payer_account_name'}] if version == '2' else []
+            return {'Columns': cols, 'PartitionKeys': [], 'Name': 'stub_table'}
+
+    stub = StubCUR.__new__(StubCUR)
+    stub.athena = None
+    stub.glue = None
+    stub.proxy = None
+    stub._metadata = None
+    # Pre-populate the tag cache so no Athena query is fired
+    stub._tag_and_cost_category = list(selectors)
+    return stub
+
+
+# ---------------------------------------------------------------------------
+# AbstractCUR.tag_fields_by_dimension
+# ---------------------------------------------------------------------------
+
+class TestTagFieldsByDimension:
+
+    def test_no_cross_dimension_returns_empty(self):
+        cur = _make_cur([
+            "resource_tags['user_owner']",
+            "tags['accountTag/cost_center']",
+        ])
+        assert cur.tag_fields_by_dimension == {}
+
+    def test_resource_and_account_same_key(self):
+        cur = _make_cur([
+            "resource_tags['user_environment']",
+            "tags['accountTag/environment']",
+        ])
+        result = cur.tag_fields_by_dimension
+        assert 'environment' in result
+        assert len(result['environment']) == 2
+        assert "resource_tags['user_environment']" in result['environment']
+        assert "tags['accountTag/environment']" in result['environment']
+
+    def test_three_way_cross_dimension(self):
+        cur = _make_cur([
+            "resource_tags['user_team']",
+            "tags['accountTag/team']",
+            "tags['iamPrincipal/team']",
+        ])
+        result = cur.tag_fields_by_dimension
+        assert 'team' in result
+        assert len(result['team']) == 3
+
+    def test_normalises_special_chars_in_key(self):
+        cur = _make_cur([
+            "resource_tags['user_my-tag']",
+            "tags['accountTag/my-tag']",
+        ])
+        result = cur.tag_fields_by_dimension
+        # hyphen is normalised to underscore in the bare key
+        assert 'my_tag' in result
+
+    def test_only_returns_multi_dimension_keys(self):
+        cur = _make_cur([
+            "resource_tags['user_env']",
+            "tags['accountTag/env']",
+            "resource_tags['user_owner']",       # owner only in one dimension
+        ])
+        result = cur.tag_fields_by_dimension
+        assert 'env' in result
+        assert 'owner' not in result
+
+    def test_cur1_returns_empty_dict(self):
+        # CUR1 has no MAP columns, merging is not applicable
+        cur = _make_cur([], version='1')
+        assert cur.tag_fields_by_dimension == {}
+
+    def test_line_item_iam_principal_bare_key(self):
+        cur = _make_cur([
+            'line_item_iam_principal',
+            "tags['iamPrincipal/iam_principal']",
+        ])
+        result = cur.tag_fields_by_dimension
+        # Both resolve to bare key 'iam_principal'
+        assert 'iam_principal' in result
+        assert len(result['iam_principal']) == 2
+
+    def test_cost_category_case_sensitive_no_merge(self):
+        # 'billing' (resource tag) vs 'Billing' (cost category) — different bare keys
+        cur = _make_cur([
+            "resource_tags['user_billing']",
+            "cost_category['Billing']",
+        ])
+        assert cur.tag_fields_by_dimension == {}
+
+
+# ---------------------------------------------------------------------------
+# Cid._selector_dimension
+# ---------------------------------------------------------------------------
+
+class TestSelectorDimension:
+    """Tests call the real static method on the real Cid class."""
+
+    @pytest.fixture(autouse=True)
+    def cid_class(self):
+        from cid.common import Cid
+        self.Cid = Cid
+
+    def test_resource_tags(self):
+        assert self.Cid._selector_dimension("resource_tags['user_env']") == 'resource_tags'
+
+    def test_account_tag(self):
+        assert self.Cid._selector_dimension("tags['accountTag/env']") == 'tags_account'
+
+    def test_iam_principal_tag(self):
+        assert self.Cid._selector_dimension("tags['iamPrincipal/team']") == 'tags_iam_principal'
+
+    def test_user_attribute_tag(self):
+        assert self.Cid._selector_dimension("tags['userAttribute/dept']") == 'tags_user_attribute'
+
+    def test_cost_category(self):
+        assert self.Cid._selector_dimension("cost_category['BillingTeam']") == 'cost_category'
+
+    def test_line_item_iam_principal(self):
+        assert self.Cid._selector_dimension('line_item_iam_principal') == 'tags_iam_principal'
+
+
+# ---------------------------------------------------------------------------
+# Cid._build_merge_sql
+# ---------------------------------------------------------------------------
+
+class TestBuildMergeSql:
+    """Tests call the real static method on the real Cid class."""
+
+    SELECTORS = [
+        "resource_tags['user_environment']",
+        "tags['accountTag/environment']",
+        "tags['iamPrincipal/environment']",
+    ]
+
+    @pytest.fixture(autouse=True)
+    def cid_class(self):
+        from cid.common import Cid
+        self.Cid = Cid
+
+    def test_resource_first_order(self):
+        sql = self.Cid._build_merge_sql('environment', self.SELECTORS, 'resource_first')
+        pos_resource = sql.index("resource_tags['user_environment']")
+        pos_account  = sql.index("tags['accountTag/environment']")
+        pos_iam      = sql.index("tags['iamPrincipal/environment']")
+        assert pos_resource < pos_iam < pos_account
+
+    def test_account_first_order(self):
+        sql = self.Cid._build_merge_sql('environment', self.SELECTORS, 'account_first')
+        pos_resource = sql.index("resource_tags['user_environment']")
+        pos_account  = sql.index("tags['accountTag/environment']")
+        assert pos_account < pos_resource
+
+    def test_coalesce_wraps_all_selectors(self):
+        sql = self.Cid._build_merge_sql('environment', self.SELECTORS, 'resource_first')
+        assert 'COALESCE' in sql
+        for sel in self.SELECTORS:
+            assert f"NULLIF({sel}, '')" in sql
+
+    def test_nullif_uses_empty_string_sentinel(self):
+        # Athena MAP accessors return '' not NULL for missing keys — NULLIF('', '') is essential
+        sql = self.Cid._build_merge_sql('env', self.SELECTORS[:2], 'resource_first')
+        assert "NULLIF(" in sql
+        assert ", '')" in sql
+
+    def test_unknown_strategy_falls_back_to_resource_first(self):
+        sql_known   = self.Cid._build_merge_sql('k', self.SELECTORS, 'resource_first')
+        sql_unknown = self.Cid._build_merge_sql('k', self.SELECTORS, 'nonexistent_strategy')
+        assert sql_known == sql_unknown
+
+    def test_two_selectors(self):
+        selectors = [
+            "resource_tags['user_env']",
+            "tags['accountTag/env']",
+        ]
+        sql = self.Cid._build_merge_sql('env', selectors, 'resource_first')
+        assert "NULLIF(resource_tags['user_env'], '')" in sql
+        assert "NULLIF(tags['accountTag/env'], '')" in sql
+
+    def test_single_selector_still_wraps_in_coalesce(self):
+        sql = self.Cid._build_merge_sql('env', self.SELECTORS[:1], 'resource_first')
+        assert 'COALESCE' in sql
+        assert "NULLIF(resource_tags['user_environment'], '')" in sql

--- a/cid/test/python/test_tag_merging.py
+++ b/cid/test/python/test_tag_merging.py
@@ -1,36 +1,36 @@
 """Unit tests for cross-dimension tag merging.
 
-These tests import and exercise the *real* production classes:
+All tests import and exercise the *real* production classes:
 - ``AbstractCUR.tag_fields_by_dimension``  (cid/helpers/cur.py)
+- ``Cid._tag_to_name``                     (cid/common.py)
 - ``Cid._selector_dimension``              (cid/common.py)
 - ``Cid._build_merge_sql``                 (cid/common.py)
-- ``Cid.generic_tags_json``                (cid/common.py)
+- ``Cid._build_tag_choices``               (cid/common.py)
+- ``Cid._build_tags_json_sql``             (cid/common.py)
 
 No AWS credentials or live Athena connections are required; both classes are
-instantiated via lightweight stubs that only satisfy the specific attributes
-exercised by the code under test.
+instantiated via lightweight stubs that only satisfy the attributes exercised
+by the code under test.
 """
 import pytest
 
+
 # ---------------------------------------------------------------------------
-# Helpers: minimal stubs that let us instantiate real classes without AWS
+# Stub: minimal AbstractCUR subclass (no Athena/Glue required)
 # ---------------------------------------------------------------------------
 
 def _make_cur(selectors, version='2'):
-    """Return a real ``AbstractCUR`` subclass instance with
-    ``tag_and_cost_category_fields`` pre-loaded from *selectors* and
-    ``version`` fixed to *version*.  No Athena/Glue clients needed.
+    """Return a real ``AbstractCUR`` subclass with ``tag_and_cost_category_fields``
+    pre-seeded from *selectors* and ``version`` fixed to *version*.
     """
     from cid.helpers.cur import AbstractCUR
 
     class StubCUR(AbstractCUR):
-        # AbstractCUR requires these two abstract-ish methods
         def ensure_column(self, column, column_type=None):
             pass
 
         @property
         def metadata(self):
-            # 'bill_payer_account_name' being present triggers version == '2'
             cols = [{'Name': 'bill_payer_account_name'}] if version == '2' else []
             return {'Columns': cols, 'PartitionKeys': [], 'Name': 'stub_table'}
 
@@ -39,7 +39,6 @@ def _make_cur(selectors, version='2'):
     stub.glue = None
     stub.proxy = None
     stub._metadata = None
-    # Pre-populate the tag cache so no Athena query is fired
     stub._tag_and_cost_category = list(selectors)
     return stub
 
@@ -84,21 +83,19 @@ class TestTagFieldsByDimension:
             "tags['accountTag/my-tag']",
         ])
         result = cur.tag_fields_by_dimension
-        # hyphen is normalised to underscore in the bare key
         assert 'my_tag' in result
 
     def test_only_returns_multi_dimension_keys(self):
         cur = _make_cur([
             "resource_tags['user_env']",
             "tags['accountTag/env']",
-            "resource_tags['user_owner']",       # owner only in one dimension
+            "resource_tags['user_owner']",
         ])
         result = cur.tag_fields_by_dimension
         assert 'env' in result
         assert 'owner' not in result
 
     def test_cur1_returns_empty_dict(self):
-        # CUR1 has no MAP columns, merging is not applicable
         cur = _make_cur([], version='1')
         assert cur.tag_fields_by_dimension == {}
 
@@ -108,12 +105,10 @@ class TestTagFieldsByDimension:
             "tags['iamPrincipal/iam_principal']",
         ])
         result = cur.tag_fields_by_dimension
-        # Both resolve to bare key 'iam_principal'
         assert 'iam_principal' in result
         assert len(result['iam_principal']) == 2
 
     def test_cost_category_case_sensitive_no_merge(self):
-        # 'billing' (resource tag) vs 'Billing' (cost category) — different bare keys
         cur = _make_cur([
             "resource_tags['user_billing']",
             "cost_category['Billing']",
@@ -122,34 +117,83 @@ class TestTagFieldsByDimension:
 
 
 # ---------------------------------------------------------------------------
+# Cid._tag_to_name
+# ---------------------------------------------------------------------------
+
+class TestTagToName:
+
+    @pytest.fixture(autouse=True)
+    def _import(self):
+        from cid.common import Cid
+        self.fn = Cid._tag_to_name
+
+    def test_resource_tag_cur2(self):
+        assert self.fn("resource_tags['user_environment']") == 'tag_environment'
+
+    def test_resource_tag_with_hyphen(self):
+        assert self.fn("resource_tags['user_my-tag']") == 'tag_my_tag'
+
+    def test_resource_tag_cur1_flat_column(self):
+        # CUR1 flat columns keep 'user_' in the name after stripping 'resource_tags_',
+        # because the 'user_' replacement only targets MAP accessor syntax ("'user_").
+        assert self.fn('resource_tags_user_environment') == 'tag_user_environment'
+
+    def test_account_tag(self):
+        assert self.fn("tags['accountTag/CostCenter']") == 'account_tag_CostCenter'
+
+    def test_iam_principal_tag(self):
+        assert self.fn("tags['iamPrincipal/Team']") == 'iam_principal_tag_Team'
+
+    def test_user_attribute_tag(self):
+        assert self.fn("tags['userAttribute/Department']") == 'user_attribute_tag_Department'
+
+    def test_cost_category_cur2(self):
+        assert self.fn("cost_category['BillingTeam']") == 'cost_category_BillingTeam'
+
+    def test_cost_category_cur1_flat_column(self):
+        assert self.fn('cost_category_BillingTeam') == 'cost_category_BillingTeam'
+
+    def test_line_item_iam_principal(self):
+        assert self.fn('line_item_iam_principal') == 'iam_principal'
+
+    def test_aws_reserved_prefix_escaped(self):
+        # 'aws_' prefix in resource tag key gets escaped to 'tag_aws_'
+        result = self.fn("resource_tags['user_aws_something']")
+        assert 'aws' in result
+
+    def test_non_word_chars_replaced_with_underscore(self):
+        result = self.fn("resource_tags['user_my.tag:name']")
+        assert re.match(r'^\w+$', result), f"Expected only word chars, got: {result}"
+
+
+# ---------------------------------------------------------------------------
 # Cid._selector_dimension
 # ---------------------------------------------------------------------------
 
 class TestSelectorDimension:
-    """Tests call the real static method on the real Cid class."""
 
     @pytest.fixture(autouse=True)
-    def cid_class(self):
+    def _import(self):
         from cid.common import Cid
-        self.Cid = Cid
+        self.fn = Cid._selector_dimension
 
     def test_resource_tags(self):
-        assert self.Cid._selector_dimension("resource_tags['user_env']") == 'resource_tags'
+        assert self.fn("resource_tags['user_env']") == 'resource_tags'
 
     def test_account_tag(self):
-        assert self.Cid._selector_dimension("tags['accountTag/env']") == 'tags_account'
+        assert self.fn("tags['accountTag/env']") == 'tags_account'
 
     def test_iam_principal_tag(self):
-        assert self.Cid._selector_dimension("tags['iamPrincipal/team']") == 'tags_iam_principal'
+        assert self.fn("tags['iamPrincipal/team']") == 'tags_iam_principal'
 
     def test_user_attribute_tag(self):
-        assert self.Cid._selector_dimension("tags['userAttribute/dept']") == 'tags_user_attribute'
+        assert self.fn("tags['userAttribute/dept']") == 'tags_user_attribute'
 
     def test_cost_category(self):
-        assert self.Cid._selector_dimension("cost_category['BillingTeam']") == 'cost_category'
+        assert self.fn("cost_category['BillingTeam']") == 'cost_category'
 
     def test_line_item_iam_principal(self):
-        assert self.Cid._selector_dimension('line_item_iam_principal') == 'tags_iam_principal'
+        assert self.fn('line_item_iam_principal') == 'tags_iam_principal'
 
 
 # ---------------------------------------------------------------------------
@@ -157,7 +201,6 @@ class TestSelectorDimension:
 # ---------------------------------------------------------------------------
 
 class TestBuildMergeSql:
-    """Tests call the real static method on the real Cid class."""
 
     SELECTORS = [
         "resource_tags['user_environment']",
@@ -166,50 +209,166 @@ class TestBuildMergeSql:
     ]
 
     @pytest.fixture(autouse=True)
-    def cid_class(self):
+    def _import(self):
         from cid.common import Cid
-        self.Cid = Cid
+        self.fn = Cid._build_merge_sql
 
     def test_resource_first_order(self):
-        sql = self.Cid._build_merge_sql('environment', self.SELECTORS, 'resource_first')
+        sql = self.fn('environment', self.SELECTORS, 'resource_first')
         pos_resource = sql.index("resource_tags['user_environment']")
         pos_account  = sql.index("tags['accountTag/environment']")
-        pos_iam      = sql.index("tags['iamPrincipal/environment']")
-        assert pos_resource < pos_iam < pos_account
+        assert pos_resource < pos_account
 
     def test_account_first_order(self):
-        sql = self.Cid._build_merge_sql('environment', self.SELECTORS, 'account_first')
+        sql = self.fn('environment', self.SELECTORS, 'account_first')
         pos_resource = sql.index("resource_tags['user_environment']")
         pos_account  = sql.index("tags['accountTag/environment']")
         assert pos_account < pos_resource
 
     def test_coalesce_wraps_all_selectors(self):
-        sql = self.Cid._build_merge_sql('environment', self.SELECTORS, 'resource_first')
+        sql = self.fn('environment', self.SELECTORS, 'resource_first')
         assert 'COALESCE' in sql
         for sel in self.SELECTORS:
             assert f"NULLIF({sel}, '')" in sql
 
     def test_nullif_uses_empty_string_sentinel(self):
-        # Athena MAP accessors return '' not NULL for missing keys — NULLIF('', '') is essential
-        sql = self.Cid._build_merge_sql('env', self.SELECTORS[:2], 'resource_first')
-        assert "NULLIF(" in sql
+        sql = self.fn('env', self.SELECTORS[:2], 'resource_first')
+        assert 'NULLIF(' in sql
         assert ", '')" in sql
 
     def test_unknown_strategy_falls_back_to_resource_first(self):
-        sql_known   = self.Cid._build_merge_sql('k', self.SELECTORS, 'resource_first')
-        sql_unknown = self.Cid._build_merge_sql('k', self.SELECTORS, 'nonexistent_strategy')
+        sql_known   = self.fn('k', self.SELECTORS, 'resource_first')
+        sql_unknown = self.fn('k', self.SELECTORS, 'nonexistent_strategy')
         assert sql_known == sql_unknown
 
     def test_two_selectors(self):
-        selectors = [
-            "resource_tags['user_env']",
-            "tags['accountTag/env']",
-        ]
-        sql = self.Cid._build_merge_sql('env', selectors, 'resource_first')
+        selectors = ["resource_tags['user_env']", "tags['accountTag/env']"]
+        sql = self.fn('env', selectors, 'resource_first')
         assert "NULLIF(resource_tags['user_env'], '')" in sql
         assert "NULLIF(tags['accountTag/env'], '')" in sql
 
     def test_single_selector_still_wraps_in_coalesce(self):
-        sql = self.Cid._build_merge_sql('env', self.SELECTORS[:1], 'resource_first')
+        sql = self.fn('env', self.SELECTORS[:1], 'resource_first')
         assert 'COALESCE' in sql
         assert "NULLIF(resource_tags['user_environment'], '')" in sql
+
+
+# ---------------------------------------------------------------------------
+# Cid._build_tag_choices
+# ---------------------------------------------------------------------------
+
+class TestBuildTagChoices:
+
+    @pytest.fixture(autouse=True)
+    def _import(self):
+        from cid.common import Cid
+        self.fn = Cid._build_tag_choices
+
+    def _tags_and_names(self):
+        from cid.common import Cid
+        selectors = [
+            "resource_tags['user_environment']",
+            "tags['accountTag/environment']",
+            "resource_tags['user_owner']",
+        ]
+        return {Cid._tag_to_name(s): s for s in selectors}
+
+    def test_no_merge_all_passthrough(self):
+        tags_and_names = self._tags_and_names()
+        merged = self.fn(tags_and_names, set(), {})
+        assert merged == {}
+
+    def test_merged_key_keeps_individual_entries(self):
+        tags_and_names = self._tags_and_names()
+        merge_map = {
+            'environment': [
+                "resource_tags['user_environment']",
+                "tags['accountTag/environment']",
+            ]
+        }
+        merged = self.fn(tags_and_names, {'environment'}, merge_map)
+        assert 'merged_environment' in merged
+
+    def test_non_merged_key_stays_in_passthrough(self):
+        tags_and_names = self._tags_and_names()
+        merge_map = {
+            'environment': [
+                "resource_tags['user_environment']",
+                "tags['accountTag/environment']",
+            ]
+        }
+        merged = self.fn(tags_and_names, {'environment'}, merge_map)
+        assert 'merged_environment' in merged
+
+    def test_merged_display_value_contains_bare_key_and_selectors(self):
+        tags_and_names = self._tags_and_names()
+        merge_map = {
+            'environment': [
+                "resource_tags['user_environment']",
+                "tags['accountTag/environment']",
+            ]
+        }
+        merged = self.fn(tags_and_names, {'environment'}, merge_map)
+        bare_key, selectors = merged['merged_environment']
+        assert bare_key == 'environment'
+        assert len(selectors) == 2
+
+
+# ---------------------------------------------------------------------------
+# Cid._build_tags_json_sql
+# ---------------------------------------------------------------------------
+
+import re
+
+class TestBuildTagsJsonSql:
+
+    @pytest.fixture(autouse=True)
+    def _import(self):
+        from cid.common import Cid
+        self.Cid = Cid
+        self.obj = Cid.__new__(Cid)  # no __init__ needed; method only uses self for _build_merge_sql
+
+    def _simple_tags_and_names(self):
+        return {
+            'tag_environment': "resource_tags['user_environment']",
+            'tag_owner':       "resource_tags['user_owner']",
+        }
+
+    def test_returns_empty_json_for_empty_selection(self):
+        result = self.obj._build_tags_json_sql([], {}, {}, 'resource_first')
+        assert result == "'{}'"
+
+    def test_plain_tag_rendered_correctly(self):
+        tags_and_names = self._simple_tags_and_names()
+        result = self.obj._build_tags_json_sql(
+            ['tag_environment'], {}, tags_and_names, 'resource_first'
+        )
+        assert "('tag_environment', resource_tags['user_environment'])" in result
+        assert 'json_format' in result
+        assert 'MAP_FROM_ENTRIES' in result
+
+    def test_merged_tag_uses_coalesce(self):
+        tags_and_names = self._simple_tags_and_names()
+        merge_map_selectors = [
+            "resource_tags['user_environment']",
+            "tags['accountTag/environment']",
+        ]
+        merged_display = {'merged_environment': ('environment', merge_map_selectors)}
+        result = self.obj._build_tags_json_sql(
+            ['merged_environment'], merged_display, tags_and_names, 'resource_first'
+        )
+        assert 'COALESCE' in result
+        assert "NULLIF(resource_tags['user_environment'], '')" in result
+
+    def test_unknown_tag_name_skipped(self):
+        result = self.obj._build_tags_json_sql(
+            ['nonexistent_tag'], {}, {}, 'resource_first'
+        )
+        assert result == "'{}'"
+
+    def test_special_chars_in_name_sanitised(self):
+        tags_and_names = {'tag_my_tag': "resource_tags['user_my-tag']"}
+        result = self.obj._build_tags_json_sql(
+            ['tag_my_tag'], {}, tags_and_names, 'resource_first'
+        )
+        assert "'tag_my_tag'" in result


### PR DESCRIPTION
*Issue #, if available:* #1475

*Description of changes:* Make merging tags on different levels possible. This is still a very early draft, I'll try to execute a first test round on our own setup.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

### Known Issues
- [x] Merging tags: it seems like an account tag results in field account_tag_BusinessSolution vs tag_business_solution for normal tags. I need to fix this before I can continue in my own setup, working on it. Resulting example diff of the `tags_json`: 
   ```diff
   - , json_format(CAST(MAP_FROM_ENTRIES(ARRAY[ROW('tag_business_solution', resource_tags['user_business_solution']),ROW('iam_principal', line_item_iam_principal),ROW('account_tag_BusinessSolution', tags['accountTag/BusinessSolution'])]) AS JSON)) tags_json
   + , json_format(CAST(MAP_FROM_ENTRIES(ARRAY[ROW('tag_business_solution', resource_tags['user_business_solution']),ROW('iam_principal', line_item_iam_principal),ROW('account_tag_BusinessSolution', tags['accountTag/BusinessSolution']),ROW('merged_business_solution', COALESCE(NULLIF(resource_tags['user_business_solution'], ''), NULLIF(cost_category['business_solution'], ''), NULLIF(tags['accountTag/BusinessSolution'], '')))]) AS JSON)) tags_json
   ```
- [x] Merging tags: these tags are not replacing existing tags per se. It can be that users want to compare merged tags against their original counterparts
- [x] Resulting merged tags are _'null'_  ➡️ only the first view was updated due to input not used in the latter pre-seeded/non-interactive runs
- [ ] Tag shows as 'Merged \<Tag Title\>'. This might need a better title, but I don't know what and how to do it (yet)
- [ ] It definitely exposes some gaps in our own tagging setup 🤣 

It needs definitely some improvements on code quality and readability, first focus was on functionality. Results look good on our version of the dashboards!
