### PR TITLE
feat(agent): Add cid-cmd create-agent / delete-agent (QuickSight Q deployment)

### DIFF
--- a/CID-CMD.md
+++ b/CID-CMD.md
@@ -115,6 +115,33 @@ Delete Command Options:
  --athena-database TEXT Athena database
 ```
 
+#### Create a QuickSight Agent
+Create an Amazon QuickSight Generative Q&A Agent for a deployed CID dashboard. The command creates a Space containing the dashboard, its datasets and an auto-generated Q Topic, then creates an Agent bound to that Space. Pre-configured templates supply curated descriptions, starter prompts and custom instructions for the common CID dashboards.
+
+```bash
+cid-cmd create-agent
+```
+
+Or target a specific template / dashboard non-interactively:
+```bash
+cid-cmd create-agent --agent-template cudos
+cid-cmd create-agent --dashboard-id cost_intelligence_dashboard
+```
+
+Create Agent Command Options:
+```
+ --agent-template TEXT  Agent template: cudos, cost_intelligence_dashboard,
+                        kpi_dashboard, ta-organizational-view, compute_optimizer
+ --dashboard-id TEXT    QuickSight dashboard id (for the [Custom] path)
+```
+
+Prerequisites: QuickSight **Enterprise** edition with **Amazon Q** enabled in a supported Region, and `boto3>=1.43.19` (the release that introduced the QuickSight Spaces/Agents APIs). The command grants the calling QuickSight user permissions on the new topic and agent.
+
+To remove the agent, topic and space created for a dashboard:
+```bash
+cid-cmd delete-agent --dashboard-id cudos
+```
+
 #### Export
 The command `export` lets you download or share a customized dashboard with another AWS Account. It takes the QuickSight Analysis as an input and generates all the assets needed to deploy your Analysis into another AWS Account. This command will generate a yaml file with a description of the Dashboard and all required Datasets. Also this command generates a QuickSight Template in the current AWS Account that can be used for Dashboard deployment in other accounts. The resource file can be used with all other cid commands. Both accounts must have relevant Athena Views and Tables.
 

--- a/cid/cli.py
+++ b/cid/cli.py
@@ -317,6 +317,7 @@ def teardown(ctx, **kwargs):
 
     ctx.obj.teardown(**kwargs)
 
+
 @click.option('--dashboard-id', help='QuickSight dashboard id', default=None)
 @click.option('--agent-template', help='Agent template name (cudos, cost_intelligence_dashboard, etc.)', default=None)
 @click.option('-v', '--verbose', count=True)
@@ -335,8 +336,24 @@ def create_agent(ctx, dashboard_id, agent_template, **kwargs):
     \b
     Available templates: cudos, cost_intelligence_dashboard, kpi_dashboard,
     ta-organizational-view, compute_optimizer
+
+    \b
+    Requires QuickSight Enterprise with Amazon Q enabled and boto3>=1.43.19.
     """
     ctx.obj.create_agent(dashboard_id=dashboard_id, agent_template=agent_template, **kwargs)
+
+
+@click.option('--dashboard-id', help='QuickSight dashboard id', default=None)
+@click.option('-v', '--verbose', count=True)
+@click.option('-y', '--yes', help='confirm all', is_flag=True, default=False)
+@cid_command
+def delete_agent(ctx, dashboard_id, **kwargs):
+    """Delete the QuickSight Agent, Topic and Space created by create-agent
+
+    \b
+    --dashboard-id TEXT   QuickSight dashboard id the agent was created for
+    """
+    ctx.obj.delete_agent(dashboard_id=dashboard_id, **kwargs)
 
 
 if __name__ == '__main__':

--- a/cid/cli.py
+++ b/cid/cli.py
@@ -317,6 +317,28 @@ def teardown(ctx, **kwargs):
 
     ctx.obj.teardown(**kwargs)
 
+@click.option('--dashboard-id', help='QuickSight dashboard id', default=None)
+@click.option('--agent-template', help='Agent template name (cudos, cost_intelligence_dashboard, etc.)', default=None)
+@click.option('-v', '--verbose', count=True)
+@click.option('-y', '--yes', help='confirm all', is_flag=True, default=False)
+@cid_command
+def create_agent(ctx, dashboard_id, agent_template, **kwargs):
+    """Create a QuickSight Agent with Space and Topic for a CID dashboard
+
+    \b
+    This command:
+    1. Shows list of available agent templates
+    2. Creates a Space containing the dashboard and its datasets
+    3. Creates a Q Topic with auto-detected column definitions
+    4. Creates an Agent linked to the Space with curated prompts
+
+    \b
+    Available templates: cudos, cost_intelligence_dashboard, kpi_dashboard,
+    ta-organizational-view, compute_optimizer
+    """
+    ctx.obj.create_agent(dashboard_id=dashboard_id, agent_template=agent_template, **kwargs)
+
+
 if __name__ == '__main__':
     main()
 

--- a/cid/common.py
+++ b/cid/common.py
@@ -2259,3 +2259,179 @@ class Cid():
         self.create_or_update_view(view_name='cur')
         cid_print('Please check crawler in a few minutes https://console.aws.amazon.com/glue/home?#/v2/data-catalog/crawlers')
         set_parameters({'cur-table-name': path_fragments[-1].lower().replace('-', '_')})
+
+    @command
+    def create_agent(self, dashboard_id=None, agent_template=None, **kwargs):
+        """Create a QuickSight Agent with Space and Topic for a CID dashboard."""
+        from uuid import uuid4
+
+        # Load agent templates
+        templates = self._load_agent_templates()
+
+        # 1. Select agent template or dashboard
+        if not agent_template and not dashboard_id:
+            # Show available agent templates
+            choices = {}
+            for key, tmpl in templates.items():
+                choices[f"{tmpl['name']} ({key})"] = key
+            choices['[Custom] Select any deployed dashboard'] = '__custom__'
+
+            agent_template = get_parameter(
+                param_name='agent-template',
+                message='Select an agent to create',
+                choices=choices,
+            )
+
+        # Resolve template config
+        if agent_template and agent_template != '__custom__':
+            tmpl = templates.get(agent_template)
+            if not tmpl:
+                cid_print(f'Unknown agent template: {agent_template}')
+                cid_print(f'Available: {", ".join(templates.keys())}')
+                return
+            dashboard_id = dashboard_id or tmpl['dashboard_id']
+            agent_name = tmpl['name']
+            description = tmpl['description']
+            starter_prompts = tmpl.get('starter_prompts', [])
+            welcome_message = tmpl.get('welcome_message', '')
+            custom_instructions = tmpl.get('custom_instructions', '')
+        else:
+            # Custom: select from deployed dashboards
+            if not dashboard_id:
+                if not self.qs.dashboards:
+                    cid_print('No deployed dashboards found')
+                    return
+                dashboard_id = self.qs.select_dashboard(force=True)
+                if not dashboard_id:
+                    cid_print('No dashboard selected')
+                    return
+            agent_name = None  # will be set from dashboard name
+            description = ''
+            starter_prompts = [
+                'What are my top cost drivers this month?',
+                'Show cost trends by service over the last 90 days',
+                'Which accounts have the highest month-over-month increase?',
+            ]
+            welcome_message = ''
+            custom_instructions = ''
+
+        # 2. Discover dashboard
+        dashboard = self.qs.dashboards.get(dashboard_id) if self.qs.dashboards else None
+        if not dashboard:
+            dashboard = self.qs.discover_dashboard(dashboard_id)
+        if not dashboard:
+            cid_print(f'Dashboard {dashboard_id} not found. Is it deployed?')
+            return
+
+        dashboard_name = dashboard.name
+        if not agent_name:
+            agent_name = f'CID - {dashboard_name}'
+        if not description:
+            description = f'AI agent for {dashboard_name}'
+        if not welcome_message:
+            welcome_message = f'Hi! I can help you explore your {dashboard_name} data. Ask me anything.'
+
+        cid_print(f'Creating agent: {agent_name}')
+
+        # 3. Create Space
+        space_id = f'cid-{dashboard_id}'
+        space_name = f'CID - {dashboard_name}'
+        try:
+            self.qs.create_space(space_id, space_name, f'Auto-created space for {dashboard_name}')
+            cid_print(f'  ✓ Space: {space_name}')
+        except self.qs.client.exceptions.ResourceExistsException:
+            cid_print(f'  · Space already exists: {space_name}')
+        except Exception as exc:
+            logger.error(f'Failed to create space: {exc}')
+            raise CidError(f'Failed to create space: {exc}')
+
+        # 4. Add dashboard and datasets to space
+        space_arn = f'arn:{self.base.partition}:quicksight:{self.qs.session.region_name}:{self.qs.account_id}:space/{space_id}'
+        resources_to_add = [{'ResourceDetails': {'Dashboard': {'DashboardId': dashboard_id}}, 'ResourceType': 'DASHBOARD'}]
+        dataset_ids = dashboard.get_dataset_ids()
+        for ds_id in dataset_ids:
+            resources_to_add.append({'ResourceDetails': {'DataSet': {'DataSetId': ds_id}}, 'ResourceType': 'DATASET'})
+
+        try:
+            self.qs.update_space_resources(space_id, add_resources=resources_to_add)
+            cid_print(f'  ✓ Added {len(resources_to_add)} resources to space')
+        except Exception as exc:
+            logger.warning(f'  ! Failed to add resources to space: {exc}')
+
+        # 5. Create Topic with column definitions from datasets
+        topic_id = f'cid-topic-{dashboard_id}'
+        datasets_config = []
+        for ds_id in dataset_ids:
+            dataset = self.qs.describe_dataset(ds_id)
+            if not dataset:
+                continue
+            columns = self.qs.build_topic_columns(ds_id)
+            if not columns:
+                continue
+            dataset_arn = f'arn:{self.base.partition}:quicksight:{self.qs.session.region_name}:{self.qs.account_id}:dataset/{ds_id}'
+            datasets_config.append({
+                'DatasetArn': dataset_arn,
+                'DatasetName': dataset.name,
+                'DatasetDescription': f'Dataset: {dataset.name}',
+                'Columns': columns,
+                'CalculatedFields': [],
+                'NamedEntities': [],
+                'Filters': [],
+            })
+
+        if datasets_config:
+            try:
+                topic_params = {
+                    'topic_id': topic_id,
+                    'name': f'CID - {dashboard_name}',
+                    'description': f'Q Topic for natural language queries on {dashboard_name}',
+                    'datasets_config': datasets_config,
+                }
+                self.qs.create_topic(**topic_params)
+                cid_print(f'  ✓ Topic: {sum(len(d["Columns"]) for d in datasets_config)} columns across {len(datasets_config)} dataset(s)')
+            except self.qs.client.exceptions.ResourceExistsException:
+                cid_print(f'  · Topic already exists')
+            except Exception as exc:
+                logger.warning(f'  ! Failed to create topic: {exc}')
+        else:
+            cid_print('  ! No datasets found, skipping topic creation')
+
+        # 6. Create Agent
+        agent_id = f'cid-agent-{dashboard_id}'
+        try:
+            agent_params = {
+                'agent_id': agent_id,
+                'name': agent_name,
+                'spaces': [space_arn],
+                'description': description,
+                'starter_prompts': starter_prompts,
+                'welcome_message': welcome_message,
+            }
+            response = self.qs.create_agent(**agent_params)
+            cid_print(f'  ✓ Agent: {agent_name} (status: {response.get("AgentStatus", "UNKNOWN")})')
+        except self.qs.client.exceptions.ResourceExistsException:
+            cid_print(f'  · Agent already exists: {agent_id}')
+        except Exception as exc:
+            logger.error(f'Failed to create agent: {exc}')
+            raise CidError(f'Failed to create agent: {exc}')
+
+        # 7. Grant permissions to current user
+        if self.qs.user:
+            user_arn = self.qs.user.get('Arn', '')
+            if user_arn:
+                try:
+                    if datasets_config:
+                        self.qs.update_topic_permissions(topic_id, user_arn)
+                    self.qs.update_agent_permissions(agent_id, user_arn)
+                    cid_print(f'  ✓ Permissions granted to: {self.qs.user.get("UserName", "")}')
+                except Exception as exc:
+                    logger.warning(f'  ! Failed to grant permissions: {exc}')
+
+        cid_print(f'\n✓ Done! Open QuickSight to interact with your new agent.')
+
+    def _load_agent_templates(self) -> dict:
+        """Load agent templates from bundled YAML."""
+        import yaml as _yaml
+        templates_path = resources.files('cid').joinpath('data/agent_templates.yaml')
+        with resources.as_file(templates_path) as f:
+            return _yaml.safe_load(f.read_text())

--- a/cid/common.py
+++ b/cid/common.py
@@ -2457,15 +2457,21 @@ class Cid():
         except ClientError as exc:
             raise CidCritical(f'Failed to create agent: {exc}') from exc
 
-        # 7. Grant permissions to current user
+        # 7. Grant permissions to current user. A freshly created agent is
+        # transiently UPDATING and rejects permission calls with
+        # ConflictException, so wait for it to settle first.
         if self.qs.user:
             user_arn = self.qs.user.get('Arn', '')
             if user_arn:
                 try:
                     if topic_created:
                         self.qs.update_topic_permissions(topic_id, user_arn)
+                    self.qs.wait_for_agent_active(agent_id)
                     self.qs.update_agent_permissions(agent_id, user_arn)
                     cid_print(f'  <GREEN>OK<END> Permissions granted to: {self.qs.user.get("UserName", "")}')
+                except self.qs.client.exceptions.ConflictException:
+                    cid_print('  ! Agent still updating; re-run create-agent once it is ACTIVE '
+                              'to grant permissions (resources were created successfully)')
                 except ClientError as exc:
                     logger.warning(f'  ! Failed to grant permissions: {exc}')
 
@@ -2496,6 +2502,10 @@ class Cid():
                 default='no'):
             cid_print('Cancelled')
             return
+
+        # An agent that is still CREATING/UPDATING rejects delete with
+        # ConflictException, so wait for it to settle first.
+        self.qs.wait_for_agent_active(agent_id)
 
         # Delete in reverse order of creation; ignore already-absent resources.
         for label, deleter, resource_id in (

--- a/cid/common.py
+++ b/cid/common.py
@@ -2262,8 +2262,20 @@ class Cid():
 
     @command
     def create_agent(self, dashboard_id=None, agent_template=None, **kwargs):
-        """Create a QuickSight Agent with Space and Topic for a CID dashboard."""
-        from uuid import uuid4
+        """Create a QuickSight Agent with Space and Topic for a CID dashboard.
+
+        Builds the full Generative Q&A stack for a deployed dashboard: a Space
+        containing the dashboard, its datasets and a Q Topic, plus an Agent
+        bound to the Space. Requires QuickSight Enterprise with Amazon Q
+        enabled in a supported Region.
+        """
+        # Verify the running SDK actually exposes the Spaces/Agents APIs
+        # (added in boto3/botocore 1.43.19) before doing any work.
+        if 'CreateAgent' not in self.qs.client.meta.service_model.operation_names:
+            raise CidCritical(
+                'The installed boto3/botocore is too old for QuickSight Agents. '
+                'Please upgrade to boto3>=1.43.19 (pip install -U boto3).'
+            )
 
         # Load agent templates
         templates = self._load_agent_templates()
@@ -2286,9 +2298,10 @@ class Cid():
         if agent_template and agent_template != '__custom__':
             tmpl = templates.get(agent_template)
             if not tmpl:
-                cid_print(f'Unknown agent template: {agent_template}')
-                cid_print(f'Available: {", ".join(templates.keys())}')
-                return
+                raise CidCritical(
+                    f'Unknown agent template: {agent_template}. '
+                    f'Available: {", ".join(templates.keys())}'
+                )
             dashboard_id = dashboard_id or tmpl['dashboard_id']
             agent_name = tmpl['name']
             description = tmpl['description']
@@ -2299,12 +2312,10 @@ class Cid():
             # Custom: select from deployed dashboards
             if not dashboard_id:
                 if not self.qs.dashboards:
-                    cid_print('No deployed dashboards found')
-                    return
+                    raise CidCritical('No deployed dashboards found')
                 dashboard_id = self.qs.select_dashboard(force=True)
                 if not dashboard_id:
-                    cid_print('No dashboard selected')
-                    return
+                    raise CidCritical('No dashboard selected')
             agent_name = None  # will be set from dashboard name
             description = ''
             starter_prompts = [
@@ -2313,15 +2324,20 @@ class Cid():
                 'Which accounts have the highest month-over-month increase?',
             ]
             welcome_message = ''
-            custom_instructions = ''
+            # Let the user supply custom instructions for the [Custom] path;
+            # empty (or <5 chars) is fine and is simply not sent to the API.
+            custom_instructions = get_parameter(
+                param_name='agent-custom-instructions',
+                message='Custom instructions for the agent (optional, press Enter to skip)',
+                default='',
+            )
 
         # 2. Discover dashboard
         dashboard = self.qs.dashboards.get(dashboard_id) if self.qs.dashboards else None
         if not dashboard:
             dashboard = self.qs.discover_dashboard(dashboard_id)
         if not dashboard:
-            cid_print(f'Dashboard {dashboard_id} not found. Is it deployed?')
-            return
+            raise CidCritical(f'Dashboard {dashboard_id} not found. Is it deployed?')
 
         dashboard_name = dashboard.name
         if not agent_name:
@@ -2331,35 +2347,45 @@ class Cid():
         if not welcome_message:
             welcome_message = f'Hi! I can help you explore your {dashboard_name} data. Ask me anything.'
 
-        cid_print(f'Creating agent: {agent_name}')
+        cid_print(f'Creating agent: <BOLD>{agent_name}<END>')
+
+        partition = self.base.partition
+        region = self.qs.session.region_name
+        account_id = self.qs.account_id
 
         # 3. Create Space
         space_id = f'cid-{dashboard_id}'
         space_name = f'CID - {dashboard_name}'
+        # Fall back to a constructed ARN; overwritten with the real one below.
+        space_arn = f'arn:{partition}:quicksight:{region}:{account_id}:space/{space_id}'
         try:
-            self.qs.create_space(space_id, space_name, f'Auto-created space for {dashboard_name}')
-            cid_print(f'  ✓ Space: {space_name}')
+            response = self.qs.create_space(space_id, space_name, f'Auto-created space for {dashboard_name}')
+            # CreateSpace returns the ARN as lowercase 'spaceArn'.
+            space_arn = response.get('spaceArn', space_arn)
+            cid_print(f'  <GREEN>OK<END> Space: {space_name}')
         except self.qs.client.exceptions.ResourceExistsException:
-            cid_print(f'  · Space already exists: {space_name}')
-        except Exception as exc:
-            logger.error(f'Failed to create space: {exc}')
-            raise CidError(f'Failed to create space: {exc}')
+            cid_print(f'  Space already exists: {space_name}')
+        except self.qs.client.exceptions.AccessDeniedException as exc:
+            raise CidCritical(f'Access denied creating space (is Amazon Q enabled?): {exc}') from exc
+        except ClientError as exc:
+            raise CidCritical(f'Failed to create space: {exc}') from exc
 
-        # 4. Add dashboard and datasets to space
-        space_arn = f'arn:{self.base.partition}:quicksight:{self.qs.session.region_name}:{self.qs.account_id}:space/{space_id}'
-        resources_to_add = [{'ResourceDetails': {'Dashboard': {'DashboardId': dashboard_id}}, 'ResourceType': 'DASHBOARD'}]
+        # 4. Add dashboard and datasets to the space. SpaceQuickSightResourceDetails
+        # is a union taking a single 'resourceArn'; ResourceType uses 'DATA_SET'.
         dataset_ids = dashboard.get_dataset_ids()
+        resources_to_add = [{
+            'ResourceType': 'DASHBOARD',
+            'ResourceDetails': {'resourceArn': f'arn:{partition}:quicksight:{region}:{account_id}:dashboard/{dashboard_id}'},
+        }]
         for ds_id in dataset_ids:
-            resources_to_add.append({'ResourceDetails': {'DataSet': {'DataSetId': ds_id}}, 'ResourceType': 'DATASET'})
-
-        try:
-            self.qs.update_space_resources(space_id, add_resources=resources_to_add)
-            cid_print(f'  ✓ Added {len(resources_to_add)} resources to space')
-        except Exception as exc:
-            logger.warning(f'  ! Failed to add resources to space: {exc}')
+            resources_to_add.append({
+                'ResourceType': 'DATA_SET',
+                'ResourceDetails': {'resourceArn': f'arn:{partition}:quicksight:{region}:{account_id}:dataset/{ds_id}'},
+            })
 
         # 5. Create Topic with column definitions from datasets
         topic_id = f'cid-topic-{dashboard_id}'
+        topic_arn = f'arn:{partition}:quicksight:{region}:{account_id}:topic/{topic_id}'
         datasets_config = []
         for ds_id in dataset_ids:
             dataset = self.qs.describe_dataset(ds_id)
@@ -2368,70 +2394,132 @@ class Cid():
             columns = self.qs.build_topic_columns(ds_id)
             if not columns:
                 continue
-            dataset_arn = f'arn:{self.base.partition}:quicksight:{self.qs.session.region_name}:{self.qs.account_id}:dataset/{ds_id}'
+            dataset_arn = f'arn:{partition}:quicksight:{region}:{account_id}:dataset/{ds_id}'
             datasets_config.append({
                 'DatasetArn': dataset_arn,
                 'DatasetName': dataset.name,
                 'DatasetDescription': f'Dataset: {dataset.name}',
                 'Columns': columns,
-                'CalculatedFields': [],
-                'NamedEntities': [],
-                'Filters': [],
             })
 
+        topic_created = False
         if datasets_config:
             try:
-                topic_params = {
-                    'topic_id': topic_id,
-                    'name': f'CID - {dashboard_name}',
-                    'description': f'Q Topic for natural language queries on {dashboard_name}',
-                    'datasets_config': datasets_config,
-                }
-                self.qs.create_topic(**topic_params)
-                cid_print(f'  ✓ Topic: {sum(len(d["Columns"]) for d in datasets_config)} columns across {len(datasets_config)} dataset(s)')
+                self.qs.create_topic(
+                    topic_id=topic_id,
+                    name=f'CID - {dashboard_name}',
+                    description=f'Q Topic for natural language queries on {dashboard_name}',
+                    datasets_config=datasets_config,
+                )
+                topic_created = True
+                cid_print(f'  <GREEN>OK<END> Topic: {sum(len(d["Columns"]) for d in datasets_config)} '
+                          f'columns across {len(datasets_config)} dataset(s)')
             except self.qs.client.exceptions.ResourceExistsException:
-                cid_print(f'  · Topic already exists')
-            except Exception as exc:
+                topic_created = True
+                cid_print('  Topic already exists')
+            except ClientError as exc:
                 logger.warning(f'  ! Failed to create topic: {exc}')
         else:
             cid_print('  ! No datasets found, skipping topic creation')
 
+        # Attach the topic to the space so the agent can use it for Q&A.
+        if topic_created:
+            resources_to_add.append({
+                'ResourceType': 'TOPIC',
+                'ResourceDetails': {'resourceArn': topic_arn},
+            })
+
+        try:
+            resp = self.qs.update_space_resources(space_id, add_resources=resources_to_add)
+            failed = resp.get('FailedResourceOperations', [])
+            ok_count = len(resources_to_add) - len(failed)
+            cid_print(f'  <GREEN>OK<END> Added {ok_count} resource(s) to space')
+            for failure in failed:
+                logger.warning(f'  ! Resource not added to space: {failure}')
+        except ClientError as exc:
+            logger.warning(f'  ! Failed to add resources to space: {exc}')
+
         # 6. Create Agent
         agent_id = f'cid-agent-{dashboard_id}'
         try:
-            agent_params = {
-                'agent_id': agent_id,
-                'name': agent_name,
-                'spaces': [space_arn],
-                'description': description,
-                'starter_prompts': starter_prompts,
-                'welcome_message': welcome_message,
-            }
-            response = self.qs.create_agent(**agent_params)
-            cid_print(f'  ✓ Agent: {agent_name} (status: {response.get("AgentStatus", "UNKNOWN")})')
+            response = self.qs.create_agent(
+                agent_id=agent_id,
+                name=agent_name,
+                spaces=[space_arn],
+                description=description,
+                starter_prompts=starter_prompts,
+                welcome_message=welcome_message,
+                custom_instructions=custom_instructions,
+            )
+            cid_print(f'  <GREEN>OK<END> Agent: {agent_name} (status: {response.get("AgentStatus", "UNKNOWN")})')
         except self.qs.client.exceptions.ResourceExistsException:
-            cid_print(f'  · Agent already exists: {agent_id}')
-        except Exception as exc:
-            logger.error(f'Failed to create agent: {exc}')
-            raise CidError(f'Failed to create agent: {exc}')
+            cid_print(f'  Agent already exists: {agent_id}')
+        except ClientError as exc:
+            raise CidCritical(f'Failed to create agent: {exc}') from exc
 
         # 7. Grant permissions to current user
         if self.qs.user:
             user_arn = self.qs.user.get('Arn', '')
             if user_arn:
                 try:
-                    if datasets_config:
+                    if topic_created:
                         self.qs.update_topic_permissions(topic_id, user_arn)
                     self.qs.update_agent_permissions(agent_id, user_arn)
-                    cid_print(f'  ✓ Permissions granted to: {self.qs.user.get("UserName", "")}')
-                except Exception as exc:
+                    cid_print(f'  <GREEN>OK<END> Permissions granted to: {self.qs.user.get("UserName", "")}')
+                except ClientError as exc:
                     logger.warning(f'  ! Failed to grant permissions: {exc}')
 
-        cid_print(f'\n✓ Done! Open QuickSight to interact with your new agent.')
+        cid_print('\n<GREEN>Done!<END> Open QuickSight to interact with your new agent.')
+
+    @command
+    def delete_agent(self, dashboard_id=None, **kwargs):
+        """Delete the QuickSight Agent, Topic and Space created for a dashboard."""
+        if 'DeleteAgent' not in self.qs.client.meta.service_model.operation_names:
+            raise CidCritical(
+                'The installed boto3/botocore is too old for QuickSight Agents. '
+                'Please upgrade to boto3>=1.43.19 (pip install -U boto3).'
+            )
+        if not dashboard_id:
+            if not self.qs.dashboards:
+                raise CidCritical('No deployed dashboards found')
+            dashboard_id = self.qs.select_dashboard(force=True)
+            if not dashboard_id:
+                raise CidCritical('No dashboard selected')
+
+        agent_id = f'cid-agent-{dashboard_id}'
+        topic_id = f'cid-topic-{dashboard_id}'
+        space_id = f'cid-{dashboard_id}'
+
+        if not get_yesno_parameter(
+                param_name='confirm',
+                message=f'Delete agent <BOLD>{agent_id}<END>, topic {topic_id} and space {space_id}?',
+                default='no'):
+            cid_print('Cancelled')
+            return
+
+        # Delete in reverse order of creation; ignore already-absent resources.
+        for label, deleter, resource_id in (
+            ('Agent', self.qs.delete_agent, agent_id),
+            ('Topic', self.qs.delete_topic, topic_id),
+            ('Space', self.qs.delete_space, space_id),
+        ):
+            try:
+                deleter(resource_id)
+                cid_print(f'  <GREEN>OK<END> Deleted {label.lower()}: {resource_id}')
+            except self.qs.client.exceptions.ResourceNotFoundException:
+                cid_print(f'  {label} not found (already deleted): {resource_id}')
+            except self.qs.client.exceptions.ConflictException:
+                # A freshly created agent may still be UPDATING; it cannot be
+                # deleted until ACTIVE. Tell the user to retry rather than fail.
+                cid_print(f'  ! {label} {resource_id} is busy (still updating) - '
+                          f'wait for it to become ACTIVE and re-run delete-agent')
+            except ClientError as exc:
+                logger.warning(f'  ! Failed to delete {label.lower()} {resource_id}: {exc}')
+
+        cid_print('\n<GREEN>Done!<END>')
 
     def _load_agent_templates(self) -> dict:
         """Load agent templates from bundled YAML."""
-        import yaml as _yaml
         templates_path = resources.files('cid').joinpath('data/agent_templates.yaml')
         with resources.as_file(templates_path) as f:
-            return _yaml.safe_load(f.read_text())
+            return yaml.safe_load(f.read_text(encoding='utf-8'))

--- a/cid/data/agent_templates.yaml
+++ b/cid/data/agent_templates.yaml
@@ -1,0 +1,58 @@
+---
+# CID Agent Templates
+# Each template defines a pre-configured agent for a specific CID dashboard
+
+cudos:
+  name: "CUDOS Cost Intelligence"
+  description: "AI agent for CUDOS - answers questions about AWS cost optimization, usage trends, and savings opportunities"
+  dashboard_id: "cudos"
+  welcome_message: "Hi! I can help you explore your CUDOS cost data. Ask me about cost trends, savings opportunities, or usage patterns."
+  starter_prompts:
+    - "What are my top 5 cost drivers this month?"
+    - "Show cost trends by service over the last 90 days"
+    - "Which accounts have the highest month-over-month cost increase?"
+  custom_instructions: "You are a cost optimization assistant. Focus on identifying savings opportunities, cost anomalies, and usage trends. When discussing costs, always mention the time period and provide comparisons to previous periods."
+
+cost_intelligence_dashboard:
+  name: "Cost Intelligence Dashboard"
+  description: "AI agent for CID - provides insights on AWS billing, reservations, and savings plans"
+  dashboard_id: "cost_intelligence_dashboard"
+  welcome_message: "Hello! I can help you understand your AWS costs and identify optimization opportunities."
+  starter_prompts:
+    - "What is my total spend this month vs last month?"
+    - "How much am I saving with Reserved Instances?"
+    - "Which services have unexpected cost spikes?"
+  custom_instructions: "You are a billing analyst assistant. Help users understand their AWS spend, RI/SP coverage, and identify cost anomalies."
+
+kpi_dashboard:
+  name: "KPI Dashboard"
+  description: "AI agent for KPI tracking - monitors key performance indicators across your AWS environment"
+  dashboard_id: "kpi_dashboard"
+  welcome_message: "Hi! I can help you track and analyze your AWS KPIs."
+  starter_prompts:
+    - "What are my current KPI trends?"
+    - "Which metrics are outside normal range?"
+    - "Show me month-over-month KPI changes"
+  custom_instructions: "You are a KPI tracking assistant. Focus on trends, anomalies, and performance relative to targets."
+
+ta-organizational-view:
+  name: "Trusted Advisor Organizational"
+  description: "AI agent for Trusted Advisor - surfaces cost, security, performance, and fault tolerance recommendations"
+  dashboard_id: "ta-organizational-view"
+  welcome_message: "Hello! I can help you understand your Trusted Advisor recommendations across your organization."
+  starter_prompts:
+    - "What are my top open Trusted Advisor recommendations?"
+    - "Which accounts have the most critical findings?"
+    - "How has my TA score changed over the past month?"
+  custom_instructions: "You are a Trusted Advisor assistant. Prioritize recommendations by potential impact and urgency. Group findings by category (cost, security, performance, fault tolerance)."
+
+compute_optimizer:
+  name: "Compute Optimizer"
+  description: "AI agent for Compute Optimizer dashboard - helps right-size compute resources"
+  dashboard_id: "compute-optimizer-dashboard"
+  welcome_message: "Hi! I can help you find compute optimization opportunities across your accounts."
+  starter_prompts:
+    - "Which instances are over-provisioned?"
+    - "What are my potential monthly savings from right-sizing?"
+    - "Show me the top 10 optimization recommendations"
+  custom_instructions: "You are a compute optimization assistant. Focus on right-sizing recommendations, potential savings, and resource utilization patterns."

--- a/cid/helpers/quicksight/__init__.py
+++ b/cid/helpers/quicksight/__init__.py
@@ -1511,3 +1511,128 @@ class QuickSight(CidBase):
             Dataset(raw1).to_diffable_structure(),
             Dataset(raw2).to_diffable_structure(),
         )
+
+
+    # ─── Agent / Space / Topic APIs ────────────────────────────────────
+
+    def create_space(self, space_id: str, name: str, description: str = '') -> dict:
+        """Create a QuickSight Space."""
+        response = self.client.create_space(
+            AwsAccountId=self.account_id,
+            SpaceId=space_id,
+            Name=name,
+            Description=description,
+        )
+        logger.info(f'Created space: {name} ({space_id})')
+        return response
+
+    def update_space_resources(self, space_id: str, add_resources: list = None, remove_resources: list = None) -> dict:
+        """Add or remove resources from a Space."""
+        params = {'AwsAccountId': self.account_id, 'SpaceId': space_id}
+        if add_resources:
+            params['AddResources'] = add_resources
+        if remove_resources:
+            params['RemoveResources'] = remove_resources
+        response = self.client.update_space_resources(**params)
+        failed = response.get('FailedResourceOperations', [])
+        if failed:
+            logger.warning(f'Some resources failed to add to space: {failed}')
+        return response
+
+    def create_topic(self, topic_id: str, name: str, description: str, datasets_config: list) -> dict:
+        """Create a Q Topic with dataset column definitions."""
+        response = self.client.create_topic(
+            AwsAccountId=self.account_id,
+            TopicId=topic_id,
+            Topic={
+                'Name': name,
+                'Description': description,
+                'DataSets': datasets_config,
+                'UserExperienceVersion': 'NEW_READER_EXPERIENCE',
+            },
+        )
+        logger.info(f'Created topic: {name} ({topic_id})')
+        return response
+
+    def create_agent(self, agent_id: str, name: str, spaces: list = None,
+                     description: str = '', starter_prompts: list = None,
+                     welcome_message: str = '') -> dict:
+        """Create a QuickSight Agent."""
+        params = {
+            'AwsAccountId': self.account_id,
+            'AgentId': agent_id,
+            'Name': name,
+        }
+        if description:
+            params['Description'] = description
+        if spaces:
+            params['Spaces'] = spaces
+        if starter_prompts:
+            params['StarterPrompts'] = starter_prompts[:3]  # API max 3
+        if welcome_message:
+            params['WelcomeMessage'] = welcome_message
+        response = self.client.create_agent(**params)
+        logger.info(f'Created agent: {name} ({agent_id}), status={response.get("AgentStatus")}')
+        return response
+
+    def update_topic_permissions(self, topic_id: str, principal_arn: str) -> dict:
+        """Grant full topic permissions to a principal."""
+        return self.client.update_topic_permissions(
+            AwsAccountId=self.account_id,
+            TopicId=topic_id,
+            GrantPermissions=[{
+                'Principal': principal_arn,
+                'Actions': [
+                    'quicksight:DescribeTopic',
+                    'quicksight:DescribeTopicRefresh',
+                    'quicksight:ListTopicRefreshSchedules',
+                    'quicksight:DescribeTopicRefreshSchedule',
+                    'quicksight:DeleteTopic',
+                    'quicksight:UpdateTopic',
+                    'quicksight:CreateTopicRefreshSchedule',
+                    'quicksight:DeleteTopicRefreshSchedule',
+                    'quicksight:UpdateTopicRefreshSchedule',
+                    'quicksight:DescribeTopicPermissions',
+                    'quicksight:UpdateTopicPermissions',
+                ],
+            }],
+        )
+
+    def update_agent_permissions(self, agent_id: str, principal_arn: str) -> dict:
+        """Grant agent permissions to a principal."""
+        return self.client.update_agent_permissions(
+            AwsAccountId=self.account_id,
+            AgentId=agent_id,
+            GrantPermissions=[{
+                'Principal': principal_arn,
+                'Actions': [
+                    'quicksight:DescribeAgent',
+                    'quicksight:UpdateAgent',
+                    'quicksight:DeleteAgent',
+                    'quicksight:DescribeAgentPermissions',
+                    'quicksight:UpdateAgentPermissions',
+                ],
+            }],
+        )
+
+    def build_topic_columns(self, dataset_id: str) -> list:
+        """Build topic column definitions from a dataset's OutputColumns."""
+        dataset = self.describe_dataset(dataset_id)
+        if not dataset or not dataset.columns:
+            return []
+        columns = []
+        for col in dataset.columns:
+            col_name = col.get('Name', '')
+            col_type = col.get('Type', 'STRING')
+            is_measure = col_type in ('INTEGER', 'DECIMAL')
+            column_def = {
+                'ColumnName': col_name,
+                'ColumnFriendlyName': col_name.replace('_', ' ').title(),
+                'ColumnDataRole': 'MEASURE' if is_measure else 'DIMENSION',
+                'Aggregation': 'SUM' if is_measure else 'COUNT',
+                'IsIncludedInTopic': True,
+            }
+            if col_type == 'DATETIME':
+                column_def['SemanticType'] = {'TypeName': 'Date'}
+            columns.append(column_def)
+        return columns

--- a/cid/helpers/quicksight/__init__.py
+++ b/cid/helpers/quicksight/__init__.py
@@ -1628,6 +1628,28 @@ class QuickSight(CidBase):
             }],
         )
 
+    def describe_agent(self, agent_id: str) -> dict:
+        """Describe a QuickSight Agent (returns the Agent structure or {})."""
+        resp = self.client.describe_agent(AwsAccountId=self.account_id, AgentId=agent_id)
+        return resp.get('Agent', resp)
+
+    def wait_for_agent_active(self, agent_id: str, attempts: int = 12, delay: int = 5) -> str:
+        """Poll until an Agent leaves CREATING/UPDATING. Returns final status.
+
+        A freshly created agent is transiently UPDATING and rejects permission
+        or delete calls with ConflictException until it settles to ACTIVE.
+        """
+        status = 'UNKNOWN'
+        for _ in range(attempts):
+            try:
+                status = self.describe_agent(agent_id).get('AgentStatus', 'UNKNOWN')
+            except self.client.exceptions.ResourceNotFoundException:
+                return 'NOT_FOUND'
+            if status not in ('CREATING', 'UPDATING'):
+                return status
+            time.sleep(delay)
+        return status
+
     def delete_agent(self, agent_id: str) -> dict:
         """Delete a QuickSight Agent."""
         response = self.client.delete_agent(AwsAccountId=self.account_id, AgentId=agent_id)
@@ -1646,19 +1668,42 @@ class QuickSight(CidBase):
         logger.info(f'Deleted space: {space_id}')
         return response
 
-    # Integer/decimal columns whose name looks like an identifier, code or
-    # year are dimensions, not additive measures - summing an account id is
-    # meaningless for Q&A. Used to refine the measure/dimension heuristic.
-    _NON_MEASURE_HINTS = ('id', 'key', 'code', 'number', 'num', 'year',
-                          'month', 'day', 'quarter', 'arn', 'account', 'zip')
+    # Whole-word tokens that mark a numeric column as an identifier/key/flag
+    # rather than an additive measure (summing an id or a boolean is
+    # meaningless for Q&A). Matched against word tokens, not substrings, so
+    # 'Monthly Revenue' is NOT caught by 'month'.
+    _NON_MEASURE_TOKENS = frozenset((
+        'id', 'ids', 'key', 'keys', 'code', 'codes', 'arn', 'arns',
+        'uuid', 'guid', 'account', 'zip', 'zipcode', 'postal',
+        'year', 'month', 'day', 'quarter', 'week', 'hour',
+    ))
+
+    @staticmethod
+    def _is_additive_measure(col_name: str, col_type: str) -> bool:
+        """Heuristic: is a numeric column an additive measure (SUM) or a
+        dimension (an id/key/flag/date-part that should not be summed)?"""
+        if col_type not in ('INTEGER', 'DECIMAL'):
+            return False
+        name_lc = col_name.lower()
+        # Boolean-style flags (is_active, has_x, isLatest) are dimensions.
+        if re.match(r'(is|has|are|was|flag)([_\s]|[A-Z])', col_name) or name_lc.startswith(('is', 'has')):
+            # be conservative: only treat as flag when it's a short prefix word
+            first = re.split(r'[_\s]|(?<=[a-z])(?=[A-Z])', col_name)[0].lower()
+            if first in ('is', 'has', 'are', 'was', 'flag'):
+                return False
+        # Whole-word token match (split on _, space, and camelCase boundaries).
+        tokens = {t.lower() for t in re.split(r'[_\s]+|(?<=[a-z])(?=[A-Z])', col_name) if t}
+        if tokens & QuickSight._NON_MEASURE_TOKENS:
+            return False
+        return True
 
     def build_topic_columns(self, dataset_id: str) -> list:
         """Build topic column definitions from a dataset's OutputColumns.
 
         Maps QuickSight column types to Q Topic ``TopicColumn`` definitions.
         Numeric columns become additive ``MEASURE`` columns unless their name
-        looks like an identifier/code/date-part (then ``DIMENSION``). Date and
-        datetime columns get a ``TimeGranularity`` (the correct field for
+        is an identifier/key/flag/date-part token (then ``DIMENSION``). Date
+        and datetime columns get a ``TimeGranularity`` (the correct field for
         date precision; ``SemanticType.TypeName='Date'`` is not an engine-
         recognized value).
         """
@@ -1669,9 +1714,7 @@ class QuickSight(CidBase):
         for col in dataset.columns:
             col_name = col.get('Name', '')
             col_type = col.get('Type', 'STRING')
-            name_lc = col_name.lower()
-            looks_like_id = any(hint in name_lc for hint in self._NON_MEASURE_HINTS)
-            is_measure = col_type in ('INTEGER', 'DECIMAL') and not looks_like_id
+            is_measure = self._is_additive_measure(col_name, col_type)
             column_def = {
                 'ColumnName': col_name,
                 'ColumnFriendlyName': col_name.replace('_', ' ').title(),

--- a/cid/helpers/quicksight/__init__.py
+++ b/cid/helpers/quicksight/__init__.py
@@ -1554,23 +1554,36 @@ class QuickSight(CidBase):
         logger.info(f'Created topic: {name} ({topic_id})')
         return response
 
-    def create_agent(self, agent_id: str, name: str, spaces: list = None,
+    def create_agent(self, agent_id: str, name: str, spaces: list = None,  # pylint: disable=too-many-arguments,too-many-positional-arguments
                      description: str = '', starter_prompts: list = None,
-                     welcome_message: str = '') -> dict:
-        """Create a QuickSight Agent."""
+                     welcome_message: str = '', custom_instructions: str = '') -> dict:
+        """Create a QuickSight Agent.
+
+        Field limits are enforced to match the CreateAgent API contract:
+        Name <= 50, Description <= 1000, WelcomeMessage <= 300, up to 3
+        StarterPrompts of <= 100 chars each, and custom_instructions (>= 5
+        chars) is carried in CustomPromptInput.NewPrompt.CustomInstructions.
+        """
         params = {
             'AwsAccountId': self.account_id,
             'AgentId': agent_id,
-            'Name': name,
+            'Name': name[:50],  # API max 50
         }
         if description:
-            params['Description'] = description
+            params['Description'] = description[:1000]  # API max 1000
         if spaces:
-            params['Spaces'] = spaces
+            params['Spaces'] = spaces[:10]  # API max 10
         if starter_prompts:
-            params['StarterPrompts'] = starter_prompts[:3]  # API max 3
+            # API: max 3 prompts, each max 100 chars
+            params['StarterPrompts'] = [p[:100] for p in starter_prompts[:3]]
         if welcome_message:
-            params['WelcomeMessage'] = welcome_message
+            params['WelcomeMessage'] = welcome_message[:300]  # API max 300
+        # Custom instructions are carried in the CustomPromptInput union via
+        # its NewPrompt member; the API rejects strings shorter than 5 chars.
+        if custom_instructions and len(custom_instructions) >= 5:
+            params['CustomPromptInput'] = {
+                'NewPrompt': {'CustomInstructions': custom_instructions}
+            }
         response = self.client.create_agent(**params)
         logger.info(f'Created agent: {name} ({agent_id}), status={response.get("AgentStatus")}')
         return response
@@ -1615,8 +1628,40 @@ class QuickSight(CidBase):
             }],
         )
 
+    def delete_agent(self, agent_id: str) -> dict:
+        """Delete a QuickSight Agent."""
+        response = self.client.delete_agent(AwsAccountId=self.account_id, AgentId=agent_id)
+        logger.info(f'Deleted agent: {agent_id}')
+        return response
+
+    def delete_topic(self, topic_id: str) -> dict:
+        """Delete a Q Topic."""
+        response = self.client.delete_topic(AwsAccountId=self.account_id, TopicId=topic_id)
+        logger.info(f'Deleted topic: {topic_id}')
+        return response
+
+    def delete_space(self, space_id: str) -> dict:
+        """Delete a QuickSight Space."""
+        response = self.client.delete_space(AwsAccountId=self.account_id, SpaceId=space_id)
+        logger.info(f'Deleted space: {space_id}')
+        return response
+
+    # Integer/decimal columns whose name looks like an identifier, code or
+    # year are dimensions, not additive measures - summing an account id is
+    # meaningless for Q&A. Used to refine the measure/dimension heuristic.
+    _NON_MEASURE_HINTS = ('id', 'key', 'code', 'number', 'num', 'year',
+                          'month', 'day', 'quarter', 'arn', 'account', 'zip')
+
     def build_topic_columns(self, dataset_id: str) -> list:
-        """Build topic column definitions from a dataset's OutputColumns."""
+        """Build topic column definitions from a dataset's OutputColumns.
+
+        Maps QuickSight column types to Q Topic ``TopicColumn`` definitions.
+        Numeric columns become additive ``MEASURE`` columns unless their name
+        looks like an identifier/code/date-part (then ``DIMENSION``). Date and
+        datetime columns get a ``TimeGranularity`` (the correct field for
+        date precision; ``SemanticType.TypeName='Date'`` is not an engine-
+        recognized value).
+        """
         dataset = self.describe_dataset(dataset_id)
         if not dataset or not dataset.columns:
             return []
@@ -1624,7 +1669,9 @@ class QuickSight(CidBase):
         for col in dataset.columns:
             col_name = col.get('Name', '')
             col_type = col.get('Type', 'STRING')
-            is_measure = col_type in ('INTEGER', 'DECIMAL')
+            name_lc = col_name.lower()
+            looks_like_id = any(hint in name_lc for hint in self._NON_MEASURE_HINTS)
+            is_measure = col_type in ('INTEGER', 'DECIMAL') and not looks_like_id
             column_def = {
                 'ColumnName': col_name,
                 'ColumnFriendlyName': col_name.replace('_', ' ').title(),
@@ -1633,6 +1680,8 @@ class QuickSight(CidBase):
                 'IsIncludedInTopic': True,
             }
             if col_type == 'DATETIME':
-                column_def['SemanticType'] = {'TypeName': 'Date'}
+                # TimeGranularity is the correct date-precision field on a
+                # TopicColumn (valid values SECOND..YEAR).
+                column_def['TimeGranularity'] = 'DAY'
             columns.append(column_def)
         return columns

--- a/cid/test/python/test_create_agent.py
+++ b/cid/test/python/test_create_agent.py
@@ -80,6 +80,29 @@ def test_build_topic_columns_measure_dimension_and_time():
     assert 'SemanticType' not in cols['usage_date']
 
 
+def test_measure_heuristic_word_boundaries_and_flags():
+    """Regression: substring matching mis-classified real columns (found in a
+    live run). 'Forecasted Monthly Revenue' must stay a MEASURE (the 'month'
+    token only matches whole words), and an 'IsLatest' flag must be a DIMENSION.
+    """
+    qs = _qs()
+    qs.describe_dataset = MagicMock(return_value=SimpleNamespace(columns=[
+        {'Name': 'Forecasted Monthly Revenue', 'Type': 'INTEGER'},
+        {'Name': 'Weighted Revenue', 'Type': 'INTEGER'},
+        {'Name': 'IsLatest', 'Type': 'INTEGER'},
+        {'Name': 'has_discount', 'Type': 'INTEGER'},
+        {'Name': 'year', 'Type': 'INTEGER'},
+        {'Name': 'order_count', 'Type': 'INTEGER'},
+    ]))
+    cols = {c['ColumnName']: c for c in qs.build_topic_columns('ds-1')}
+    assert cols['Forecasted Monthly Revenue']['ColumnDataRole'] == 'MEASURE'
+    assert cols['Weighted Revenue']['ColumnDataRole'] == 'MEASURE'
+    assert cols['order_count']['ColumnDataRole'] == 'MEASURE'
+    assert cols['IsLatest']['ColumnDataRole'] == 'DIMENSION'
+    assert cols['has_discount']['ColumnDataRole'] == 'DIMENSION'
+    assert cols['year']['ColumnDataRole'] == 'DIMENSION'
+
+
 def test_update_space_resources_payload_shape():
     """ResourceDetails must be the resourceArn union; enum is DATA_SET / TOPIC."""
     qs = _qs()

--- a/cid/test/python/test_create_agent.py
+++ b/cid/test/python/test_create_agent.py
@@ -1,0 +1,107 @@
+""" Tests for the QuickSight Agent / Space / Topic helpers used by
+`cid-cmd create-agent`. All AWS I/O is mocked - no live calls are made.
+"""
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from cid.helpers.quicksight import QuickSight
+
+
+def _qs():
+    """A QuickSight helper with a mocked boto3 client (no real session)."""
+    qs = QuickSight.__new__(QuickSight)
+    qs.client = MagicMock()
+    # account_id is a read-only property backed by awsIdentity
+    qs.awsIdentity = {'Account': '123456789012'}
+    return qs
+
+
+def test_create_agent_wires_custom_instructions():
+    """custom_instructions must be sent via CustomPromptInput.NewPrompt."""
+    qs = _qs()
+    qs.client.create_agent.return_value = {'AgentStatus': 'CREATING'}
+    qs.create_agent(
+        agent_id='cid-agent-cudos',
+        name='CUDOS Cost Intelligence',
+        spaces=['arn:aws:quicksight:us-east-1:123456789012:space/cid-cudos'],
+        description='AI agent for CUDOS',
+        starter_prompts=['What are my top cost drivers?'],
+        welcome_message='Hi!',
+        custom_instructions='You are a cost optimization assistant.',
+    )
+    kwargs = qs.client.create_agent.call_args.kwargs
+    assert kwargs['CustomPromptInput'] == {
+        'NewPrompt': {'CustomInstructions': 'You are a cost optimization assistant.'}
+    }
+    assert kwargs['AgentId'] == 'cid-agent-cudos'
+
+
+def test_create_agent_omits_short_instructions():
+    """Instructions shorter than the API minimum (5 chars) are not sent."""
+    qs = _qs()
+    qs.client.create_agent.return_value = {'AgentStatus': 'CREATING'}
+    qs.create_agent(agent_id='a', name='n', custom_instructions='hi')
+    assert 'CustomPromptInput' not in qs.client.create_agent.call_args.kwargs
+
+
+def test_create_agent_enforces_api_limits():
+    """Name <=50, StarterPrompts max 3 and each <=100 chars."""
+    qs = _qs()
+    qs.client.create_agent.return_value = {}
+    qs.create_agent(
+        agent_id='a',
+        name='X' * 80,
+        starter_prompts=['p' * 200, 'b', 'c', 'd'],
+    )
+    kwargs = qs.client.create_agent.call_args.kwargs
+    assert len(kwargs['Name']) == 50
+    assert len(kwargs['StarterPrompts']) == 3
+    assert all(len(p) <= 100 for p in kwargs['StarterPrompts'])
+
+
+def test_build_topic_columns_measure_dimension_and_time():
+    """Numeric -> MEASURE/SUM, id-like numeric -> DIMENSION, datetime -> TimeGranularity."""
+    qs = _qs()
+    qs.describe_dataset = MagicMock(return_value=SimpleNamespace(columns=[
+        {'Name': 'spend', 'Type': 'DECIMAL'},
+        {'Name': 'account_id', 'Type': 'INTEGER'},
+        {'Name': 'service', 'Type': 'STRING'},
+        {'Name': 'usage_date', 'Type': 'DATETIME'},
+    ]))
+    cols = {c['ColumnName']: c for c in qs.build_topic_columns('ds-1')}
+
+    assert cols['spend']['ColumnDataRole'] == 'MEASURE'
+    assert cols['spend']['Aggregation'] == 'SUM'
+    # identifier-like integer must NOT be summed
+    assert cols['account_id']['ColumnDataRole'] == 'DIMENSION'
+    assert cols['service']['ColumnDataRole'] == 'DIMENSION'
+    # datetime uses TimeGranularity, NOT SemanticType TypeName='Date'
+    assert cols['usage_date']['TimeGranularity'] == 'DAY'
+    assert 'SemanticType' not in cols['usage_date']
+
+
+def test_update_space_resources_payload_shape():
+    """ResourceDetails must be the resourceArn union; enum is DATA_SET / TOPIC."""
+    qs = _qs()
+    qs.client.update_space_resources.return_value = {'FailedResourceOperations': []}
+    add = [
+        {'ResourceType': 'DASHBOARD', 'ResourceDetails': {'resourceArn': 'arn:aws:quicksight:us-east-1:123456789012:dashboard/cudos'}},
+        {'ResourceType': 'DATA_SET', 'ResourceDetails': {'resourceArn': 'arn:aws:quicksight:us-east-1:123456789012:dataset/ds-1'}},
+        {'ResourceType': 'TOPIC', 'ResourceDetails': {'resourceArn': 'arn:aws:quicksight:us-east-1:123456789012:topic/cid-topic-cudos'}},
+    ]
+    qs.update_space_resources('cid-cudos', add_resources=add)
+    sent = qs.client.update_space_resources.call_args.kwargs['AddResources']
+    types = {r['ResourceType'] for r in sent}
+    assert types == {'DASHBOARD', 'DATA_SET', 'TOPIC'}
+    for r in sent:
+        assert set(r['ResourceDetails'].keys()) == {'resourceArn'}
+
+
+def test_create_topic_uses_new_reader_experience():
+    """Topic must request the NEW_READER_EXPERIENCE generative-Q experience."""
+    qs = _qs()
+    qs.client.create_topic.return_value = {}
+    qs.create_topic(topic_id='t', name='n', description='d', datasets_config=[{'DatasetArn': 'a'}])
+    topic = qs.client.create_topic.call_args.kwargs['Topic']
+    assert topic['UserExperienceVersion'] == 'NEW_READER_EXPERIENCE'
+    assert topic['DataSets'] == [{'DatasetArn': 'a'}]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-boto3>=1.35.86
+boto3>=1.43.19
 Click>=8.0
 PyYAML
 requests

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ include_package_data = True
 packages = find_namespace:
 install_requires =
     setuptools
-    boto3>=1.35.86
+    boto3>=1.43.19
     Click>=8.0
     PyYAML
     requests


### PR DESCRIPTION
## What this does

Adds `cid-cmd create-agent` — a single command that stands up an Amazon QuickSight **Generative Q&A Agent** for a CID dashboard, plus the matching `cid-cmd delete-agent` teardown command.

`create-agent` builds the full Q stack for a deployed dashboard:
1. Creates a **Space** containing the dashboard, its datasets, and a Q **Topic**
2. Creates the **Topic** with auto-detected column definitions (measures/dimensions, date granularity)
3. Creates the **Agent** bound to the Space, with curated starter prompts, welcome message, and custom instructions
4. Grants permissions on the topic and agent to the calling QuickSight user

Five pre-configured agent templates ship in `cid/data/agent_templates.yaml` (CUDOS, Cost Intelligence Dashboard, KPI, Trusted Advisor, Compute Optimizer). A `[Custom]` path lets you target any deployed dashboard and supply your own instructions.

```bash
cid-cmd create-agent                                   # interactive template picker
cid-cmd create-agent --agent-template cudos            # specific template
cid-cmd create-agent --dashboard-id <id>               # any deployed dashboard
cid-cmd delete-agent --dashboard-id <id>               # tear it all down
```

## Verification

- **Live end-to-end** on QuickSight Enterprise: `create-agent` against a real dashboard created Space + Topic (12 real columns, correct roles) + Agent with custom instructions, granted permissions; `delete-agent` removed all three. Account verified clean afterward.

## Dependency

Bumps the `boto3` floor to `>=1.43.19` in `requirements.txt` and `setup.cfg` — the release that introduced `CreateAgent` / `CreateSpace` / `UpdateSpaceResources` (verified: absent in 1.43.18, present in 1.43.19). Requires QuickSight **Enterprise** with Amazon Q enabled in a supported Region.

## Context

This is the first building block of the broader **cid-cmd Agent & Flow deployment platform** — a curated library of deployable Quick Agents (Operations, FinOps, Security) and Quick Flows, installable with a single command. `create-agent` establishes the agent-deployment path; `create-flow` and the contribution model follow.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
