### PR TITLE
fix(summary_view): preserve EDP discount refunds on Savings Plans (#1497)

### DIFF
--- a/cid/builtin/core/data/queries/cid/summary_view.sql
+++ b/cid/builtin/core/data/queries/cid/summary_view.sql
@@ -71,7 +71,7 @@
       WHEN ("line_item_line_item_type" = 'DiscountedUsage') THEN "reservation_effective_cost"
       WHEN ("line_item_line_item_type" = 'RIFee') THEN ("reservation_unused_amortized_upfront_fee_for_billing_period" + "reservation_unused_recurring_fee")
       WHEN (("line_item_line_item_type" = 'Fee') AND ("reservation_reservation_a_r_n" <> '')) THEN 0
-      WHEN (("line_item_line_item_type" = 'Refund') AND ("line_item_product_code" = 'ComputeSavingsPlans')) THEN 0
+      WHEN (("line_item_line_item_type" = 'Refund') AND ("line_item_product_code" = 'ComputeSavingsPlans') AND ("line_item_line_item_description" LIKE 'Refund for one-time fee for Savings Plan ID%')) THEN 0
       ELSE "line_item_unblended_cost"
     END) "amortized_cost"
   , sum(CASE


### PR DESCRIPTION
## Problem

PR #1112 added a `WHEN` clause that zeros **all** Refund rows where `line_item_product_code = 'ComputeSavingsPlans'`, to suppress the cosmetic artifact from Savings Plans returned within the 7-day window. However, it also zeros legitimate **EDP/PPA discount refunds** attributed to the SP product, causing `amortized_cost` to disagree with Cost Explorer (reported in #1497).

## Fix

Narrow the predicate to match the cancellation artifact by its description:

```sql
WHEN (("line_item_line_item_type" = 'Refund')
      AND ("line_item_product_code" = 'ComputeSavingsPlans')
      AND ("line_item_line_item_description" LIKE 'Refund for one-time fee for Savings Plan ID%'))
THEN 0
```

- SP cancellation refunds carry the description `Refund for one-time fee for Savings Plan ID: <id>` → still zeroed (preserves PR #1112's intent).
- EDP/PPA discount refunds have a different description → fall through to `ELSE line_item_unblended_cost` and now surface correctly.

## Why not #1496

PR #1496 proposed gating on `savings_plan_savings_plan_a_r_n <> '' AND date_diff(start, end) <= 7`. Validation against live CUR data showed the actual within-7-day SP cancellation refund rows have **empty** `savings_plan_savings_plan_a_r_n`, `savings_plan_start_time`, and `savings_plan_end_time`. That predicate would therefore **never match** the cancellation rows — regressing PR #1112 (the cosmetic artifact would reappear) without cleanly separating EDP refunds. The `line_item_line_item_description` prefix is the reliable discriminator.

## Verification

Validated against real CUR data:
- The within-7-day SP cancellation refund row → still zeroed ✓
- Refund rows with any other description (EDP/PPA discounts) → fall through to `line_item_unblended_cost` ✓

Performance: no extra S3 scan (column already referenced in the view); the anchored-prefix `LIKE` is gated behind two equality checks, so it only evaluates on the handful of SP refund rows.

Closes #1497
Relates-to: #1112, #1496