### PR TITLE
Feature - CSV only workflow, Modification: Naming of workflow options

### DIFF
--- a/.ai/specs/advanced-account-mapper/design.md
+++ b/.ai/specs/advanced-account-mapper/design.md
@@ -181,7 +181,7 @@ The output columns are compatible with the legacy `account_map_cur2.sql` templat
 | `account_name` | `org.name` | CSV account_name column (or account_id) |
 | `parent_account_id` | `org.managementaccountid` | NULL |
 | `parent_account_name` | CASE expression from `payer_names` config | NULL |
-| (taxonomy dimensions) | Configured by user | Selected CSV columns |
+| (taxonomy dimensions) | Configured by user | Selected CSV columns (optionally renamed) |
 
 ## Data Source Modes
 
@@ -199,8 +199,11 @@ When the user selects "CSV file only":
 1. Prompts for file path (or uses `--file` if provided)
 2. Auto-detects `account_id` and `account_name` columns
 3. Remaining columns are offered as taxonomy dimensions
-4. Output includes `parent_account_id` and `parent_account_name` (NULL) for dashboard compatibility
-5. Creates a VALUES-based view (splits into multiple parts + UNION if > 262KB)
+4. Optionally rename the selected columns to friendly, SQL-safe dimension
+   names (same prompt as the organization_data workflow; default keeps the
+   original CSV header). Renamed names become the output view column names.
+5. Output includes `parent_account_id` and `parent_account_name` (NULL) for dashboard compatibility
+6. Creates a VALUES-based view (splits into multiple parts + UNION if > 262KB)
 
 ### Both mode
 

--- a/.ai/specs/advanced-account-mapper/design.md
+++ b/.ai/specs/advanced-account-mapper/design.md
@@ -169,7 +169,7 @@ FROM optimization_data.organization_data org
 |---|---|
 | `account_map` | Main enriched account mapping view used by dashboards |
 | `account_map_config` | Stores configuration for reuse on subsequent runs |
-| `account_map_file_source` | (Only with `--file`) Stores CSV data as Athena view for JOINs |
+| `account_map_file_source` | (With `--file` or CSV-only mode) Stores file/CSV data as an Athena view |
 
 ## Output Column Compatibility
 
@@ -202,8 +202,13 @@ When the user selects "CSV file only":
 4. Optionally rename the selected columns to friendly, SQL-safe dimension
    names (same prompt as the organization_data workflow; default keeps the
    original CSV header). Renamed names become the output view column names.
-5. Output includes `parent_account_id` and `parent_account_name` (NULL) for dashboard compatibility
-6. Creates a VALUES-based view (splits into multiple parts + UNION if > 262KB)
+5. Rows are normalized (zero-padded account IDs, `parent_account_id` and
+   `parent_account_name` as NULL for dashboard compatibility)
+6. Writes through the same `AthenaWriter.write_complete_mapping()` orchestrator
+   as the other modes: orphan part-view cleanup, then the normalized rows are
+   materialized as the `account_map_file_source` VALUES view (auto-split into
+   part views + UNION if > 262KB), the config view is saved, and `account_map`
+   is created as a thin `SELECT ... FROM account_map_file_source` view.
 
 ### Both mode
 

--- a/cid/helpers/account_mapper_helpers.py
+++ b/cid/helpers/account_mapper_helpers.py
@@ -2098,7 +2098,8 @@ class UnifiedWorkflow:
         transform_engine = TransformEngine(config, org_data, file_data)
         transformed_data = transform_engine.transform()
 
-        # Add payer_name column to preview if payer names are configured
+        # Add parent_account_name (payer friendly labels) to the preview,
+        # mirroring the CASE column the generated SQL produces
         payer_names = config.get('payer_names', {})
         if payer_names and transformed_data and 'parent_account_id' in transformed_data[0]:
             for row in transformed_data:
@@ -2126,9 +2127,7 @@ class UnifiedWorkflow:
         # Phase 6: Write Views
         logger.info("Writing views to Athena...")
         results = self.writer.write_complete_mapping(config, transformed_data, target_database, self.view_name)
-        results['status'] = 'success'
-
-        return results
+        return self._derive_status(results, config)
 
     def _prompt_data_source_mode(self, source_file: str = None) -> str:
         """
@@ -2200,24 +2199,61 @@ class UnifiedWorkflow:
                 name_col = candidate
                 break
 
+        # Determine the payer (management) account ID column. A column named
+        # parent_account_id (any case/spacing) is used directly, matching the
+        # --simple mode contract. Otherwise the user can point at a column,
+        # or decline — then parent_account_id defaults to '0' like --simple.
+        parent_col = next(
+            (c for c in all_columns
+             if c.lower().replace(' ', '_') == 'parent_account_id' and c != 'account_id'),
+            None
+        )
+        if parent_col:
+            cid_print(f"   Using column '{parent_col}' as parent_account_id")
+        else:
+            has_payer_col = inquirer.confirm(
+                message="Does the file contain a column with the payer (management) account ID?",
+                default=False
+            ).execute()
+            if has_payer_col:
+                parent_col = inquirer.select(
+                    message="Select the payer account ID column:",
+                    choices=[c for c in all_columns if c not in ('account_id', name_col)]
+                ).execute()
+
         # Select taxonomy dimensions and optional friendly names (shared)
+        exclude = {c for c in (name_col, parent_col) if c}
         dimension_names = self._select_file_dimensions(
             csv_data,
             reserved={'account_id', 'account_name', 'parent_account_id', 'parent_account_name'},
-            exclude_columns={name_col} if name_col else None,
+            exclude_columns=exclude or None,
         )
         selected_columns = list(dimension_names.keys())
 
+        # Offer friendly names for the payer accounts (shared prompt).
+        # parent_account_name holds these friendly labels and is only
+        # created when names were defined — same rule as the org-based mode.
+        payer_names = {}
+        if parent_col:
+            payer_name_config = {}
+            self._prompt_payer_names(payer_name_config, csv_data, payer_column=parent_col)
+            payer_names = payer_name_config.get('payer_names', {})
+
         # Build transformed rows for the VALUES-based view
-        # Include parent_account_id and parent_account_name to match the default
-        # account_map schema expected by dashboards
         transformed_data = []
         for row in csv_data:
             account_id = row['account_id']
             out_row = {'account_id': account_id}
             out_row['account_name'] = str(row.get(name_col, account_id)) if name_col else account_id
-            out_row['parent_account_id'] = ''
-            out_row['parent_account_name'] = ''
+            if parent_col:
+                parent_id = str(row.get(parent_col, '')).strip()
+                out_row['parent_account_id'] = parent_id.zfill(12) if parent_id else '0'
+            else:
+                # No payer column in the file — same default as --simple mode
+                out_row['parent_account_id'] = '0'
+            if payer_names:
+                pid = out_row['parent_account_id']
+                out_row['parent_account_name'] = payer_names.get(pid, pid)
             for col in selected_columns:
                 out_row[dimension_names[col]] = str(row.get(col, ''))
             transformed_data.append(out_row)
@@ -2245,6 +2281,8 @@ class UnifiedWorkflow:
                 'data': transformed_data,
             },
         }
+        if payer_names:
+            config['payer_names'] = payer_names
 
         # Preview and confirmation (same UX as the other workflow modes)
         writer = AthenaWriter(config, self.athena)
@@ -2257,8 +2295,37 @@ class UnifiedWorkflow:
         # account_map view.
         logger.info("Writing views to Athena...")
         results = writer.write_complete_mapping(config, transformed_data, target_database, self.view_name)
-        results['status'] = 'success'
+        return self._derive_status(results, config)
 
+    @staticmethod
+    def _derive_status(results: dict, config: dict) -> dict:
+        """
+        Derive the workflow status from what was actually created.
+
+        write_complete_mapping records None for any view it failed to
+        create; reflect that in the returned status instead of reporting
+        success unconditionally.
+
+        Args:
+            results: Results dict from write_complete_mapping
+            config: Configuration used for the run
+
+        Returns:
+            The results dict with 'status' (and 'message' on failure) set
+        """
+        expected = ['account_map_view', 'config_view']
+        if config.get('file_source'):
+            expected.append('file_source_view')
+
+        failed = [view for view in expected if not results.get(view)]
+        if failed:
+            results['status'] = 'failed'
+            results['message'] = f"Failed to create: {', '.join(failed)}"
+            logger.error("Account mapping failed. Views not created: %s", ', '.join(failed))
+            cid_print(f"\n❌ Failed to create: {', '.join(failed)}")
+            cid_print("   Check cid.log for details.")
+        else:
+            results['status'] = 'success'
         return results
 
     def _check_existing_config(self, database: str) -> Optional[dict]:
@@ -2406,6 +2473,22 @@ class UnifiedWorkflow:
                         'source_type': 'file',
                         'source_value': col
                     })
+
+            # Validate that every file dimension references a column present
+            # in the new file. If the user kept the previous selection but the
+            # new file lacks those columns, the generated SQL would select
+            # non-existent columns and fail with an opaque Athena error.
+            available_columns = set(file_df[0].keys()) if file_df else set()
+            stale_dims = [
+                dim for dim in config['taxonomy_dimensions']
+                if dim['source_type'] == 'file' and dim['source_value'] not in available_columns
+            ]
+            if stale_dims:
+                stale_names = ', '.join(dim['name'] for dim in stale_dims)
+                cid_print(f"\n⚠️  Removing dimension(s) whose source column is not in the new file: {stale_names}")
+                config['taxonomy_dimensions'] = [
+                    dim for dim in config['taxonomy_dimensions'] if dim not in stale_dims
+                ]
 
             # Update file source info
             config['file_source'] = {
@@ -2713,27 +2796,31 @@ class UnifiedWorkflow:
 
         return levels
 
-    def _prompt_payer_names(self, config: dict, org_data: List[Dict]) -> dict:
+    def _prompt_payer_names(self, config: dict, org_data: List[Dict],
+                            payer_column: str = 'payer_id') -> dict:
         """
         Prompt user to assign friendly names to management account IDs.
 
-        Discovers distinct payer IDs from org data and asks if the user wants
-        to provide custom names. Stores the mapping in config['payer_names'].
+        Discovers distinct payer IDs from the given rows and asks if the user
+        wants to provide custom names. Stores the mapping in config['payer_names'].
+        Shared by the organization_data workflow (payer_id column) and the
+        CSV-only workflow (user-selected payer column).
 
         Args:
             config: Current configuration dictionary
-            org_data: Organization List[Dict] with payer_id column
+            org_data: List[Dict] rows containing the payer column
+            payer_column: Name of the column holding payer account IDs
 
         Returns:
             dict: Updated configuration with optional payer_names
         """
 
-        if not org_data or 'payer_id' not in org_data[0]:
-            logger.debug("No payer_id column in org data, skipping payer naming")
+        if not org_data or payer_column not in org_data[0]:
+            logger.debug("No %s column in data, skipping payer naming", payer_column)
             return config
 
         # Get distinct payer IDs
-        unique_payers = set(str(r.get('payer_id', '')).zfill(12) for r in org_data if not _is_null(r.get('payer_id')))
+        unique_payers = set(str(r.get(payer_column, '')).strip().zfill(12) for r in org_data if not _is_null(r.get(payer_column)))
         unique_payers = sorted(unique_payers)
 
         if not unique_payers:
@@ -3410,8 +3497,11 @@ SELECT {select_clause} FROM (
                 'file.account_id',
                 'file.account_name',
                 'file.parent_account_id',
-                'file.parent_account_name',
             ]
+            # parent_account_name (payer friendly labels) only exists when
+            # names were defined — same rule as the org-based mode
+            if config.get('payer_names'):
+                select_parts.append('file.parent_account_name')
             dim_names = sorted(
                 {d['name'] for d in taxonomy_dimensions}, key=str.lower
             )
@@ -3432,7 +3522,9 @@ FROM {database}.{file_source_view} file"""
             'org.managementaccountid AS parent_account_id'
         ]
         
-        # Add payer_name column if payer names are configured
+        # parent_account_name holds the user-defined friendly labels for the
+        # payer accounts. Only emitted when names were configured — same
+        # rule as CSV-only mode.
         payer_names = config.get('payer_names', {})
         if payer_names:
             case_parts = []

--- a/cid/helpers/account_mapper_helpers.py
+++ b/cid/helpers/account_mapper_helpers.py
@@ -39,6 +39,41 @@ def _path_is_file(path) -> bool:
         return False
 
 
+def _normalize_file_account_ids(rows: List[Dict], account_col: str) -> List[Dict]:
+    """
+    Normalize CSV account IDs for joining with organization data.
+
+    Single place where file account IDs are made comparable to org.id,
+    irrespective of workflow mode:
+    - Renames the account column to 'account_id' (kept as first column)
+    - Zero-pads IDs to 12 digits (Excel and some exports strip leading zeros)
+    - Drops rows with an empty/invalid account ID
+
+    Args:
+        rows: Raw CSV rows (List[Dict])
+        account_col: Name of the column holding account IDs
+
+    Returns:
+        New List[Dict] with normalized 'account_id' column
+    """
+    normalized = []
+    skipped = 0
+    for row in rows:
+        account_id = str(row.get(account_col, '')).strip().zfill(12)
+        if not account_id or account_id == '000000000000':
+            skipped += 1
+            continue
+        out_row = {'account_id': account_id}
+        # Exclude the source account column and any stray 'account_id'
+        # column so it cannot clobber the normalized value
+        out_row.update({k: v for k, v in row.items() if k not in (account_col, 'account_id')})
+        normalized.append(out_row)
+
+    if skipped:
+        logger.warning("Skipped %d row(s) with empty/invalid account ID", skipped)
+    return normalized
+
+
 def _quote_ident(name: str) -> str:
     """Quote a SQL identifier, escaping embedded double quotes."""
     return '"' + str(name).replace('"', '""') + '"'
@@ -1823,6 +1858,108 @@ class UnifiedWorkflow:
 
         return mapping
 
+    @staticmethod
+    def _normalize_file_account_ids(rows: List[Dict], account_col: str) -> List[Dict]:
+        """Normalize CSV account IDs (see module-level _normalize_file_account_ids)."""
+        return _normalize_file_account_ids(rows, account_col)
+
+    def _select_account_column(self, file_df: List[Dict]) -> str:
+        """
+        Auto-detect the account ID column or prompt the user to select it.
+
+        Args:
+            file_df: Loaded CSV rows
+
+        Returns:
+            Name of the account ID column
+        """
+        account_col = self.discovery.discover_account_id_column(file_df)
+        if not account_col:
+            account_col = inquirer.select(
+                message="Select the account ID column:",
+                choices=list(file_df[0].keys()) if file_df else []
+            ).execute()
+        else:
+            cid_print(f"   Auto-detected account ID column: {account_col}")
+        return account_col
+
+    def _load_file_source(self, source_file: str = None,
+                          use_glob_picker: bool = False) -> Tuple[str, List[Dict]]:
+        """
+        Resolve a CSV path, load it, and normalize account IDs.
+
+        Shared entry point for every workflow mode that ingests a CSV, so
+        reading (BOM/whitespace handling via DataLoader), account column
+        selection and zero-padding behave identically everywhere.
+
+        Args:
+            source_file: Optional path (prompts if not provided)
+            use_glob_picker: Use the glob-based file picker instead of the
+                             plain filepath prompt when prompting
+
+        Returns:
+            Tuple of (file path as str, normalized rows with 'account_id' column)
+
+        Raises:
+            CidCritical: If the file is empty or contains no valid account rows
+        """
+        if not source_file:
+            if use_glob_picker:
+                source_file = self.discovery.prompt_file_selection()
+            else:
+                source_file = inquirer.filepath(
+                    message="Enter path to CSV file:",
+                    validate=lambda x: _path_is_file(x) or "File not found"
+                ).execute()
+
+        file_path = _expand_path(source_file)
+        cid_print(f"\n📁 Reading CSV file: {file_path}")
+
+        loader = DataLoader(self.athena, {})
+        file_df = loader.load_from_file(str(file_path))
+        if not file_df:
+            raise CidCritical("CSV file is empty")
+
+        cid_print(f"   {len(file_df)} accounts loaded\n")
+
+        account_col = self._select_account_column(file_df)
+        file_df = self._normalize_file_account_ids(file_df, account_col)
+        if not file_df:
+            raise CidCritical("No valid account rows found in CSV")
+
+        return str(file_path), file_df
+
+    def _select_file_dimensions(self, file_df: List[Dict], reserved=None,
+                                exclude_columns=None) -> dict:
+        """
+        Let the user pick CSV columns as taxonomy dimensions and rename them.
+
+        Shared by all workflow modes. Excludes 'account_id' (the normalized
+        join column) and any additional columns the caller reserves.
+
+        Args:
+            file_df: Normalized CSV rows (account column already 'account_id')
+            reserved: Names the final dimension names must not collide with
+            exclude_columns: Columns to exclude from the dimension choices
+                             (e.g. a detected account name column)
+
+        Returns:
+            dict mapping selected source column -> final dimension name
+        """
+        skip = {'account_id'} | set(exclude_columns or ())
+        file_columns = [c for c in (file_df[0].keys() if file_df else []) if c not in skip]
+
+        if not file_columns:
+            return {}
+
+        cid_print(f"   Detected taxonomy columns: {', '.join(file_columns)}")
+        selected_columns = self._checkbox_with_retry(
+            message="Select columns to include as taxonomy dimensions (space to select, Enter to confirm):",
+            choices=file_columns
+        )
+
+        return self._prompt_dimension_renames(selected_columns, reserved=reserved)
+
     def _set_athena_parameters(self, target_database: str) -> None:
         """
         Pre-set Athena database/workgroup parameters to avoid later prompts.
@@ -1903,12 +2040,8 @@ class UnifiedWorkflow:
         with spinner("Checking for existing configuration"):
             existing_config = self._check_existing_config(target_database)
 
-        # For 'both' mode, ensure a file is available for interactive config
-        if data_source_mode == 'both' and not source_file:
-            source_file = inquirer.filepath(
-                message="Enter path to CSV file:",
-                validate=lambda x: _path_is_file(x) or "File not found"
-            ).execute()
+        # File prompting happens lazily inside _load_file_source, exactly
+        # where a CSV is actually needed (new config or file source update)
         effective_source_file = source_file
 
         if existing_config:
@@ -2047,49 +2180,10 @@ class UnifiedWorkflow:
             dict: Results containing created view names and status
         """
 
-        # Get file path
-        if not source_file:
-            source_file = inquirer.filepath(
-                message="Enter path to CSV file:",
-                validate=lambda x: _path_is_file(x) or "File not found"
-            ).execute()
-
-        file_path = _expand_path(source_file)
-        if not file_path.is_file():
-            raise CidCritical(f"File not found: {source_file}")
-
-        cid_print(f"\n📁 Reading CSV file: {file_path}")
-
-        # Load CSV data. utf-8-sig transparently strips a UTF-8 BOM if present
-        # (e.g. exports from AWS Organizations / Excel). With plain utf-8 the
-        # BOM sticks to the first quoted header and the embedded quotes end up
-        # in the column name, producing invalid Athena SQL later.
-        with open(file_path, newline='', encoding='utf-8-sig') as f:
-            reader = csv.DictReader(f, skipinitialspace=True)
-            csv_data = list(reader)
-
-        if not csv_data:
-            raise CidCritical("CSV file is empty")
-
-        # Strip whitespace from column names and values, skip None keys
-        csv_data = [
-            {k.strip(): v.strip() if isinstance(v, str) else v
-             for k, v in row.items() if k is not None}
-            for row in csv_data
-        ]
-
-        cid_print(f"   {len(csv_data)} accounts loaded\n")
-
-        # Auto-detect account_id column
-        account_col = self.discovery.discover_account_id_column(csv_data)
-        if not account_col:
-            columns = list(csv_data[0].keys())
-            account_col = inquirer.select(
-                message="Select the account ID column:",
-                choices=columns
-            ).execute()
-        else:
-            cid_print(f"   Auto-detected account ID column: {account_col}")
+        # Load and normalize the CSV through the shared file source pipeline
+        # (path prompt, ~ expansion, BOM handling, account column selection,
+        # 12-digit zero-padding — identical to the 'both' workflow mode)
+        file_path, csv_data = self._load_file_source(source_file)
 
         # Discover target database
         target_database = self.discovery.discover_target_database()
@@ -2097,44 +2191,29 @@ class UnifiedWorkflow:
         # Pre-set Athena parameters (shared with the other workflow modes)
         self._set_athena_parameters(target_database)
 
-        # Determine columns: account_id + account_name (if present) + taxonomy dimensions
+        # Detect an account name column (CSV-only specific: it feeds the
+        # account_name output column instead of being a taxonomy dimension)
         all_columns = list(csv_data[0].keys())
         name_col = None
         for candidate in ['account_name', 'name', 'Name', 'Account Name', 'AccountName']:
-            if candidate in all_columns and candidate != account_col:
+            if candidate in all_columns and candidate != 'account_id':
                 name_col = candidate
                 break
 
-        # Taxonomy columns = everything except account_id and account_name
-        skip_cols = {account_col}
-        if name_col:
-            skip_cols.add(name_col)
-        taxonomy_columns = [c for c in all_columns if c not in skip_cols]
-
-        if taxonomy_columns:
-            cid_print(f"\n   Detected taxonomy columns: {', '.join(taxonomy_columns)}")
-            selected_columns = self._checkbox_with_retry(
-                message="Select columns to include as taxonomy dimensions (space to select, Enter to confirm):",
-                choices=taxonomy_columns
-            )
-        else:
-            selected_columns = []
-
-        # Optionally rename selected columns to friendly dimension names
-        # (shared with the organization_data workflow; default keeps headers).
-        dimension_names = self._prompt_dimension_renames(
-            selected_columns,
+        # Select taxonomy dimensions and optional friendly names (shared)
+        dimension_names = self._select_file_dimensions(
+            csv_data,
             reserved={'account_id', 'account_name', 'parent_account_id', 'parent_account_name'},
+            exclude_columns={name_col} if name_col else None,
         )
+        selected_columns = list(dimension_names.keys())
 
         # Build transformed rows for the VALUES-based view
         # Include parent_account_id and parent_account_name to match the default
         # account_map schema expected by dashboards
         transformed_data = []
         for row in csv_data:
-            account_id = str(row.get(account_col, '')).strip().zfill(12)
-            if not account_id or account_id == '000000000000':
-                continue
+            account_id = row['account_id']
             out_row = {'account_id': account_id}
             out_row['account_name'] = str(row.get(name_col, account_id)) if name_col else account_id
             out_row['parent_account_id'] = ''
@@ -2142,9 +2221,6 @@ class UnifiedWorkflow:
             for col in selected_columns:
                 out_row[dimension_names[col]] = str(row.get(col, ''))
             transformed_data.append(out_row)
-
-        if not transformed_data:
-            raise CidCritical("No valid account rows found in CSV")
 
         # Build config for persistence. The transformed rows (final columns,
         # normalized account IDs) are carried as the file source data so the
@@ -2301,60 +2377,40 @@ class UnifiedWorkflow:
         if update_file:
             # Run file selection workflow
             logger.info("Updating file source...")
-            
-            # Use --file parameter if provided, otherwise prompt
-            if source_file:
-                file_path = source_file
-                cid_print(f"Using file: {source_file}")
-            else:
-                file_path = self.discovery.prompt_file_selection()
 
-            # Load file to get columns
-            temp_loader = DataLoader(self.athena, config)
-            file_df = temp_loader.load_from_file(file_path)
+            # Load and normalize the CSV through the shared file source
+            # pipeline. Uses the glob-based picker when no --file was given
+            # (existing UX for updating a file source).
+            file_path, file_df = self._load_file_source(
+                source_file, use_glob_picker=not source_file
+            )
 
-            # Auto-detect or prompt for account ID column
-            account_col = self.discovery.discover_account_id_column(file_df)
-            if not account_col:
-                account_col = inquirer.select(
-                    message="Select the account ID column:",
-                    choices=list(file_df[0].keys()) if file_df else []
-                ).execute()
-            else:
-                logger.info("Auto-detected account ID column: %s", account_col)
+            # Select taxonomy dimensions and optional friendly names (shared)
+            dimension_names = self._select_file_dimensions(
+                file_df,
+                reserved={
+                    d['name'] for d in config['taxonomy_dimensions']
+                    if d['source_type'] != 'file'
+                },
+            )
 
-            # Get file columns for dimensions (excluding account ID column)
-            file_columns = [col for col in (file_df[0].keys() if file_df else []) if col != account_col]
-
-            # Ask which columns to use as taxonomy dimensions
-            if file_columns:
-                selected_columns = self._checkbox_with_retry(
-                    message="Select which columns to use as taxonomy dimensions (space to select, Enter to confirm):",
-                    choices=file_columns
-                )
-
-                if selected_columns:
-                    # Replace any previous file dimensions with the new selection
-                    config['taxonomy_dimensions'] = [
-                        dim for dim in config['taxonomy_dimensions']
-                        if dim['source_type'] != 'file'
-                    ]
-
-                    dimension_names = self._prompt_dimension_renames(
-                        selected_columns,
-                        reserved={d['name'] for d in config['taxonomy_dimensions']},
-                    )
-                    for col, name in dimension_names.items():
-                        config['taxonomy_dimensions'].append({
-                            'name': name,
-                            'source_type': 'file',
-                            'source_value': col
-                        })
+            if dimension_names:
+                # Replace any previous file dimensions with the new selection
+                config['taxonomy_dimensions'] = [
+                    dim for dim in config['taxonomy_dimensions']
+                    if dim['source_type'] != 'file'
+                ]
+                for col, name in dimension_names.items():
+                    config['taxonomy_dimensions'].append({
+                        'name': name,
+                        'source_type': 'file',
+                        'source_value': col
+                    })
 
             # Update file source info
             config['file_source'] = {
                 'path': file_path,
-                'account_column': account_col,
+                'account_column': 'account_id',
                 'data': file_df
             }
             config['metadata']['file_source_view'] = file_source_view
@@ -2414,66 +2470,38 @@ class UnifiedWorkflow:
         use_file = "Additional file (CSV)" in data_sources
         use_name_split = "Split account name column" in data_sources
 
-        # If file selected but no path provided, prompt for it
-        if use_file and not source_file:
-            source_file = inquirer.filepath(
-                message="Enter path to CSV file:",
-                validate=lambda x: _path_is_file(x) or "File not found"
-            ).execute()
-
         # Configure file source if selected
         if use_file:
             cid_print("\n" + "="*70)
             cid_print("📁 FILE SOURCE CONFIGURATION")
             cid_print("="*70)
-            cid_print(f"Using file: {source_file}\n")
-            
-            # Use the provided file path directly
-            file_path = source_file
 
-            # Load file to get columns
-            temp_loader = DataLoader(self.athena, config)
-            file_df = temp_loader.load_from_file(file_path)
-
-            # Auto-detect or prompt for account ID column
-            account_col = self.discovery.discover_account_id_column(file_df)
-            if not account_col:
-                account_col = inquirer.select(
-                    message="Select the account ID column:",
-                    choices=list(file_df[0].keys()) if file_df else []
-                ).execute()
-            else:
-                logger.info("Auto-detected account ID column: %s", account_col)
+            # Load and normalize the CSV through the shared file source
+            # pipeline (~ expansion, BOM handling, account column selection,
+            # 12-digit zero-padding — identical to the CSV-only mode). The
+            # normalized 'account_id' column guarantees the Athena LEFT JOIN
+            # on org.id matches the same rows the Python preview matches.
+            file_path, file_df = self._load_file_source(source_file)
 
             # Store file source info
             config['file_source'] = {
                 'path': file_path,
-                'account_column': account_col,
+                'account_column': 'account_id',
                 'data': file_df
             }
             config['metadata']['file_source_view'] = f"{self.view_name}_file_source"
 
-            # Get file columns for dimensions (excluding account ID column)
-            file_columns = [col for col in (file_df[0].keys() if file_df else []) if col != account_col]
-
-            # Ask which columns to use as taxonomy dimensions
-            if file_columns:
-                selected_columns = self._checkbox_with_retry(
-                    message="Select which columns to use as taxonomy dimensions (space to select, Enter to confirm):",
-                    choices=file_columns
-                )
-
-                if selected_columns:
-                    dimension_names = self._prompt_dimension_renames(
-                        selected_columns,
-                        reserved={d['name'] for d in config['taxonomy_dimensions']},
-                    )
-                    for col, name in dimension_names.items():
-                        config['taxonomy_dimensions'].append({
-                            'name': name,
-                            'source_type': 'file',
-                            'source_value': col
-                        })
+            # Select taxonomy dimensions and optional friendly names (shared)
+            dimension_names = self._select_file_dimensions(
+                file_df,
+                reserved={d['name'] for d in config['taxonomy_dimensions']},
+            )
+            for col, name in dimension_names.items():
+                config['taxonomy_dimensions'].append({
+                    'name': name,
+                    'source_type': 'file',
+                    'source_value': col
+                })
 
         # Configure OU hierarchy level if selected
         if use_ou_level:
@@ -3155,10 +3183,13 @@ SELECT {select_clause} FROM (
                 file_df = list(config['file_source']['data'])
                 account_col = config['file_source']['account_column']
                 
-                # Rename account column to account_id for JOIN compatibility
+                # Normalize account IDs (rename to 'account_id' + 12-digit
+                # zero-padding). No-op for data that already went through
+                # _load_file_source; covers configs from older runs where
+                # the raw account column was carried through.
+                file_df = _normalize_file_account_ids(file_df, account_col)
                 if account_col != 'account_id':
-                    file_df = [{('account_id' if k == account_col else k): v for k, v in row.items()} for row in file_df]
-                    logger.info("Renamed column '%s' to 'account_id' for file source view", account_col)
+                    logger.info("Normalized column '%s' to 'account_id' for file source view", account_col)
                 
                 with spinner("Creating file source view"):
                     success = self.create_file_source_view(file_df, file_view_name, database)

--- a/cid/helpers/account_mapper_helpers.py
+++ b/cid/helpers/account_mapper_helpers.py
@@ -2178,7 +2178,7 @@ class UnifiedWorkflow:
                 if source_type == 'name_split' and isinstance(source_value, dict):
                     created_from = f"Account name split by \"{source_value.get('separator')}\" at index {source_value.get('index')}"
                 elif source_type == 'ou_level':
-                    created_from = f"OU hierarchy level {source_value}"
+                    created_from = f"OU name (level {source_value})"
                 elif source_type == 'file':
                     created_from = f"File column \"{source_value}\""
                 elif source_type == 'tag':
@@ -2358,8 +2358,8 @@ class UnifiedWorkflow:
 
         # Build data source choices — always include file option
         data_source_choices = [
-            "Tags from source table",
-            "OU hierarchy level",
+            "Account/OU tags",
+            "OU name",
             "Additional file (CSV)",
             "Split account name column",
         ]
@@ -2368,11 +2368,11 @@ class UnifiedWorkflow:
         data_sources = self._checkbox_with_retry(
             message="Select data sources for taxonomy dimensions (space to select, Enter to confirm):",
             choices=data_source_choices,
-            default=["Tags from source table"]
+            default=["Account/OU tags"]
         )
 
-        use_tags = "Tags from source table" in data_sources
-        use_ou_level = "OU hierarchy level" in data_sources
+        use_tags = "Account/OU tags" in data_sources
+        use_ou_level = "OU name" in data_sources
         use_file = "Additional file (CSV)" in data_sources
         use_name_split = "Split account name column" in data_sources
 
@@ -2455,7 +2455,7 @@ class UnifiedWorkflow:
         # Configure OU hierarchy level if selected
         if use_ou_level:
             cid_print("\n" + "="*70)
-            cid_print("🏢 OU HIERARCHY LEVEL CONFIGURATION")
+            cid_print("🏢 OU NAME CONFIGURATION")
             cid_print("="*70)
             cid_print("Extract taxonomy dimensions from the organizational unit hierarchy.")
             cid_print("Each level represents a position in the OU path.\n")

--- a/cid/helpers/account_mapper_helpers.py
+++ b/cid/helpers/account_mapper_helpers.py
@@ -1748,6 +1748,56 @@ class UnifiedWorkflow:
 
         return name
 
+    def _prompt_dimension_renames(self, columns: list, reserved=None) -> dict:
+        """
+        Ask the user to optionally rename source columns to friendly, SQL-safe
+        dimension names. Shared by the organization_data ("Additional file")
+        workflow and the CSV-only workflow so the rename experience is identical.
+
+        A single confirm gates the whole set; declining keeps the original
+        column names. Provided names are validated and sanitized as SQL
+        identifiers, then de-duplicated by appending _2, _3, ... while also
+        staying clear of any names in ``reserved``.
+
+        Args:
+            columns: Ordered list of source column names to offer for renaming
+            reserved: Optional iterable of names the result must not collide with
+                      (e.g. reserved output columns or existing dimensions)
+
+        Returns:
+            dict mapping each source column -> final dimension name (input order)
+        """
+        mapping = {}
+        if not columns:
+            return mapping
+
+        used = set(reserved or ())
+        customize = inquirer.confirm(
+            message="Do you want to rename any taxonomy dimensions from the file?",
+            default=False
+        ).execute()
+
+        for col in columns:
+            if customize:
+                new_name = inquirer.text(
+                    message=f"Name for dimension '{col}' (press Enter to keep):",
+                    default=col,
+                    validate=lambda x: self.config_mgr._validate_dimension_name(x) if x and x.strip() else True
+                ).execute()
+                new_name = self.config_mgr._sanitize_dimension_name(new_name) or col
+            else:
+                new_name = col
+
+            # De-duplicate against reserved names and earlier selections
+            base, i = new_name, 2
+            while new_name in used:
+                new_name = f"{base}_{i}"
+                i += 1
+            used.add(new_name)
+            mapping[col] = new_name
+
+        return mapping
+
     def execute(self, source_file: str = None, source_database: str = None) -> dict:
         """
         Execute the complete workflow with auto-discovery.
@@ -2044,6 +2094,13 @@ class UnifiedWorkflow:
         else:
             selected_columns = []
 
+        # Optionally rename selected columns to friendly dimension names
+        # (shared with the organization_data workflow; default keeps headers).
+        dimension_names = self._prompt_dimension_renames(
+            selected_columns,
+            reserved={'account_id', 'account_name', 'parent_account_id', 'parent_account_name'},
+        )
+
         # Build transformed rows for the VALUES-based view
         # Include parent_account_id and parent_account_name to match the default
         # account_map schema expected by dashboards
@@ -2057,7 +2114,7 @@ class UnifiedWorkflow:
             out_row['parent_account_id'] = ''
             out_row['parent_account_name'] = ''
             for col in selected_columns:
-                out_row[col] = str(row.get(col, ''))
+                out_row[dimension_names[col]] = str(row.get(col, ''))
             transformed_data.append(out_row)
 
         if not transformed_data:
@@ -2072,7 +2129,7 @@ class UnifiedWorkflow:
                 'data_source_mode': 'csv_only',
             },
             'taxonomy_dimensions': [
-                {'name': col, 'source_type': 'file', 'source_value': col}
+                {'name': dimension_names[col], 'source_type': 'file', 'source_value': col}
                 for col in selected_columns
             ],
             'file_source': {
@@ -2278,35 +2335,17 @@ class UnifiedWorkflow:
                 )
 
                 if selected_columns:
-                    # Prompt for dimension name customization
-                    customize = inquirer.confirm(
-                        message="Do you want to rename any taxonomy dimensions from the file?",
-                        default=False
-                    ).execute()
-
-                    dimension_names = {}
-                    if customize:
-                        for col in selected_columns:
-                            new_name = inquirer.text(
-                                message=f"Name for dimension '{col}' (press Enter to keep):",
-                                default=col,
-                                validate=lambda x: self.config_mgr._validate_dimension_name(x) if x and x.strip() else True
-                            ).execute()
-                            # Sanitize the dimension name (replace spaces with underscores)
-                            new_name = self.config_mgr._sanitize_dimension_name(new_name)
-                            dimension_names[col] = new_name
-                    else:
-                        dimension_names = {col: col for col in selected_columns}
-
-                    # Remove old file dimensions from config
+                    # Replace any previous file dimensions with the new selection
                     config['taxonomy_dimensions'] = [
                         dim for dim in config['taxonomy_dimensions']
                         if dim['source_type'] != 'file'
                     ]
 
-                    # Add new file dimensions to config
+                    dimension_names = self._prompt_dimension_renames(
+                        selected_columns,
+                        reserved={d['name'] for d in config['taxonomy_dimensions']},
+                    )
                     for col, name in dimension_names.items():
-                        name = self._resolve_dimension_name(name, config)
                         config['taxonomy_dimensions'].append({
                             'name': name,
                             'source_type': 'file',
@@ -2426,26 +2465,11 @@ class UnifiedWorkflow:
                 )
 
                 if selected_columns:
-                    # Prompt for dimension name customization
-                    customize = inquirer.confirm(
-                        message="Do you want to rename any taxonomy dimensions from the file?",
-                        default=False
-                    ).execute()
-
-                    dimension_names = {}
-                    if customize:
-                        for col in selected_columns:
-                            new_name = inquirer.text(
-                                message=f"Name for dimension '{col}' (press Enter to keep):",
-                                default=col
-                            ).execute()
-                            dimension_names[col] = new_name
-                    else:
-                        dimension_names = {col: col for col in selected_columns}
-
-                    # Add file dimensions to config
+                    dimension_names = self._prompt_dimension_renames(
+                        selected_columns,
+                        reserved={d['name'] for d in config['taxonomy_dimensions']},
+                    )
                     for col, name in dimension_names.items():
-                        name = self._resolve_dimension_name(name, config)
                         config['taxonomy_dimensions'].append({
                             'name': name,
                             'source_type': 'file',

--- a/cid/helpers/account_mapper_helpers.py
+++ b/cid/helpers/account_mapper_helpers.py
@@ -1798,6 +1798,33 @@ class UnifiedWorkflow:
 
         return mapping
 
+    def _set_athena_parameters(self, target_database: str) -> None:
+        """
+        Pre-set Athena database/workgroup parameters to avoid later prompts.
+
+        Auto-selects the workgroup when exactly one real workgroup exists
+        (excluding UI "(create new)" placeholder entries) and falls back to
+        'primary' when none exist. Shared by all workflow modes.
+
+        Args:
+            target_database: Database to set as the active athena-database
+        """
+        from cid.utils import set_parameters, get_parameters
+        params = get_parameters()
+        params['athena-database'] = target_database
+
+        workgroups = [wg['Name'] for wg in self.athena.list_work_groups()]
+        real_workgroups = [wg for wg in workgroups if not wg.endswith('(create new)')]
+
+        if len(real_workgroups) == 1:
+            logger.info("Auto-selected workgroup: %s", real_workgroups[0])
+            params['athena-workgroup'] = real_workgroups[0]
+        elif len(real_workgroups) == 0:
+            logger.info("No workgroups found, using default 'primary'")
+            params['athena-workgroup'] = 'primary'
+
+        set_parameters(params)
+
     def execute(self, source_file: str = None, source_database: str = None) -> dict:
         """
         Execute the complete workflow with auto-discovery.
@@ -1845,24 +1872,7 @@ class UnifiedWorkflow:
         logger.info("Target database for views: %s", target_database)
 
         # Pre-set Athena parameters BEFORE any queries to avoid prompts
-        from cid.utils import set_parameters, get_parameters
-        params = get_parameters()
-        params['athena-database'] = target_database
-
-        # Auto-select workgroup if only one real workgroup exists (excluding "create new" options)
-        workgroups = [wg['Name'] for wg in self.athena.list_work_groups()]
-        # Filter out any that might be added by the UI as "create new" options
-        real_workgroups = [wg for wg in workgroups if not wg.endswith('(create new)')]
-
-        if len(real_workgroups) == 1:
-            logger.info("Auto-selected workgroup: %s", real_workgroups[0])
-            params['athena-workgroup'] = real_workgroups[0]
-        elif len(real_workgroups) == 0:
-            # No workgroups exist, use default 'primary'
-            logger.info("No workgroups found, using default 'primary'")
-            params['athena-workgroup'] = 'primary'
-
-        set_parameters(params)
+        self._set_athena_parameters(target_database)
 
         # Phase 2: Configuration — load/save config from target database
         with spinner("Checking for existing configuration"):
@@ -2011,7 +2021,6 @@ class UnifiedWorkflow:
         Returns:
             dict: Results containing created view names and status
         """
-        from cid.utils import set_parameters, get_parameters
 
         # Get file path
         if not source_file:
@@ -2057,19 +2066,8 @@ class UnifiedWorkflow:
         # Discover target database
         target_database = self.discovery.discover_target_database()
 
-        # Pre-set Athena parameters
-        params = get_parameters()
-        params['athena-database'] = target_database
-
-        workgroups = [wg['Name'] for wg in self.athena.list_work_groups()]
-        real_workgroups = [wg for wg in workgroups if not wg.endswith('(create new)')]
-
-        if len(real_workgroups) == 1:
-            params['athena-workgroup'] = real_workgroups[0]
-        elif len(real_workgroups) == 0:
-            params['athena-workgroup'] = 'primary'
-
-        set_parameters(params)
+        # Pre-set Athena parameters (shared with the other workflow modes)
+        self._set_athena_parameters(target_database)
 
         # Determine columns: account_id + account_name (if present) + taxonomy dimensions
         all_columns = list(csv_data[0].keys())
@@ -2120,71 +2118,44 @@ class UnifiedWorkflow:
         if not transformed_data:
             raise CidCritical("No valid account rows found in CSV")
 
-        # Build config for persistence
+        # Build config for persistence. The transformed rows (final columns,
+        # normalized account IDs) are carried as the file source data so the
+        # shared writer materializes them as the account_map_file_source view
+        # (including 262KB split + UNION handling), exactly like other modes.
+        file_source_view = f"{self.view_name}_file_source"
         config = {
             'metadata': {
                 'source_database': None,
                 'source_table': None,
                 'target_database': target_database,
                 'data_source_mode': 'csv_only',
+                'file_source_view': file_source_view,
             },
             'taxonomy_dimensions': [
-                {'name': dimension_names[col], 'source_type': 'file', 'source_value': col}
+                {'name': dimension_names[col], 'source_type': 'file', 'source_value': dimension_names[col]}
                 for col in selected_columns
             ],
             'file_source': {
                 'path': str(source_file),
-                'account_column': account_col,
-                'data': csv_data,
+                'account_column': 'account_id',
+                'data': transformed_data,
             },
         }
 
-        # Preview
-        cid_print(f"\n📋 Preview ({min(10, len(transformed_data))} of {len(transformed_data)} rows):\n")
-        sample = transformed_data[:10]
-        if sample:
-            headers = list(sample[0].keys())
-            col_widths = {h: max(len(h), max(len(str(row.get(h, ''))) for row in sample)) for h in headers}
-            header_line = ' | '.join(h.ljust(col_widths[h]) for h in headers)
-            cid_print(f"  {header_line}")
-            cid_print(f"  {'-+-'.join('-' * col_widths[h] for h in headers)}")
-            for row in sample:
-                row_line = ' | '.join(str(row.get(h, '')).ljust(col_widths[h]) for h in headers)
-                cid_print(f"  {row_line}")
-
-        cid_print("")
-        confirm = inquirer.confirm(
-            message=f"Create account_map view with {len(transformed_data)} accounts in database '{target_database}'?",
-            default=True
-        ).execute()
-
-        if not confirm:
+        # Preview and confirmation (same UX as the other workflow modes)
+        writer = AthenaWriter(config, self.athena)
+        sql = writer._generate_account_map_transformation_sql(config, self.view_name, target_database)
+        if not self._preview_and_confirm(sql, transformed_data[:10]):
             return {"status": "cancelled", "message": "User cancelled operation"}
 
-        # Write the view using VALUES clause
-        writer = AthenaWriter(config, self.athena)
-        with spinner("Creating account_map view"):
-            view_names = writer.create_view_from_values(
-                transformed_data, self.view_name, target_database
-            )
+        # Write all views through the shared orchestrator: orphan part-view
+        # cleanup, file source view (with split/UNION), config view, and the
+        # account_map view.
+        logger.info("Writing views to Athena...")
+        results = writer.write_complete_mapping(config, transformed_data, target_database, self.view_name)
+        results['status'] = 'success'
 
-        # Create union view if split
-        if len(view_names) > 1:
-            with spinner("Creating union view"):
-                writer.create_union_view(view_names, self.view_name, target_database)
-
-        # Save config view
-        config_mgr = ConfigManager(self.athena, self.view_name)
-        with spinner("Saving configuration"):
-            config_mgr.save_to_view(config, target_database)
-
-        return {
-            'status': 'success',
-            'account_map_view': self.view_name,
-            'config_view': f"{self.view_name}_config",
-            'file_source_view': None,
-            'deleted_views': [],
-        }
+        return results
 
     def _check_existing_config(self, database: str) -> Optional[dict]:
         """
@@ -3366,7 +3337,31 @@ SELECT {select_clause} FROM (
         
         # Get taxonomy dimensions
         taxonomy_dimensions = config.get('taxonomy_dimensions', [])
-        
+
+        # File-only mode (no source table, e.g. "CSV file only"): the file
+        # source view already holds the complete account list with final
+        # column names, so account_map is a thin view over it. The heavy
+        # lifting (VALUES materialization, 262KB split + UNION) is done by
+        # create_file_source_view via the shared writer path.
+        if not source_table:
+            if not file_source_view:
+                raise RuntimeError("Config has neither source_table nor file_source_view")
+            select_parts = [
+                'file.account_id',
+                'file.account_name',
+                'file.parent_account_id',
+                'file.parent_account_name',
+            ]
+            dim_names = sorted(
+                {d['name'] for d in taxonomy_dimensions}, key=str.lower
+            )
+            select_parts.extend(f'file."{name}"' for name in dim_names)
+            select_clause = ',\n    '.join(select_parts)
+            return f"""CREATE OR REPLACE VIEW {database}.{view_name} AS
+SELECT
+    {select_clause}
+FROM {database}.{file_source_view} file"""
+
         # Track dimension names to detect duplicates
         dimension_names_used = set()
         

--- a/cid/helpers/account_mapper_helpers.py
+++ b/cid/helpers/account_mapper_helpers.py
@@ -21,6 +21,29 @@ logger = logging.getLogger(__name__)
 ALLOWED_SEPARATORS = set('-_./|:@# ')
 
 
+def _expand_path(path) -> Path:
+    """Expand ~ and ~user in a user-supplied file path.
+
+    InquirerPy's filepath prompt completes paths like '~/Downloads/file.csv'
+    but returns them verbatim, so every consumer must expand the home prefix
+    before touching the filesystem.
+    """
+    return Path(str(path)).expanduser()
+
+
+def _path_is_file(path) -> bool:
+    """Check whether a user-supplied path (possibly ~-prefixed) is a file."""
+    try:
+        return _expand_path(path).is_file()
+    except (OSError, ValueError):
+        return False
+
+
+def _quote_ident(name: str) -> str:
+    """Quote a SQL identifier, escaping embedded double quotes."""
+    return '"' + str(name).replace('"', '""') + '"'
+
+
 def _validate_separator(sep: str) -> bool:
     """Validate that a separator is safe for use in SQL split_part()."""
     return bool(sep) and len(sep) <= 2 and all(c in ALLOWED_SEPARATORS for c in sep)
@@ -600,12 +623,12 @@ class DataLoader:
         if not file_path:
             raise ValueError("File path must be provided or configured in file_source.file_path")
         
-        file_path_obj = Path(file_path)
-        
+        file_path_obj = _expand_path(file_path)
+
         if not file_path_obj.exists():
             raise FileNotFoundError(f"File not found: {file_path}")
         
-        logger.info("Loading data from file: %s", file_path)
+        logger.info("Loading data from file: %s", file_path_obj)
         
         # Determine file format from extension
         suffix = file_path_obj.suffix.lower()
@@ -613,7 +636,9 @@ class DataLoader:
         try:
             if suffix != '.csv':
                 raise ValueError(f"Unsupported file format: {suffix}. Only .csv is supported.")
-            with open(file_path, newline='', encoding='utf-8') as f:
+            # utf-8-sig transparently strips a UTF-8 BOM if present (e.g. exports
+            # from AWS Organizations / Excel); behaves like utf-8 otherwise.
+            with open(file_path_obj, newline='', encoding='utf-8-sig') as f:
                 reader = csv.DictReader(f, skipinitialspace=True)
                 rows = list(reader)
             # Strip whitespace from column names and values, skip None keys
@@ -1637,7 +1662,7 @@ class AutoDiscovery:
             # Fall back to manual entry
             selected_file = inquirer.text(
                 message="No files found. Enter file path manually:",
-                validate=lambda path: Path(path).is_file() or "File does not exist"
+                validate=lambda path: _path_is_file(path) or "File does not exist"
             ).execute()
         else:
             # Add option to enter path manually
@@ -1652,7 +1677,7 @@ class AutoDiscovery:
             if selected == "[Enter path manually]":
                 selected_file = inquirer.text(
                     message="Enter file path:",
-                    validate=lambda path: Path(path).is_file() or "File does not exist"
+                    validate=lambda path: _path_is_file(path) or "File does not exist"
                 ).execute()
             else:
                 selected_file = selected
@@ -1882,7 +1907,7 @@ class UnifiedWorkflow:
         if data_source_mode == 'both' and not source_file:
             source_file = inquirer.filepath(
                 message="Enter path to CSV file:",
-                validate=lambda x: Path(x).is_file() or "File not found"
+                validate=lambda x: _path_is_file(x) or "File not found"
             ).execute()
         effective_source_file = source_file
 
@@ -2026,17 +2051,20 @@ class UnifiedWorkflow:
         if not source_file:
             source_file = inquirer.filepath(
                 message="Enter path to CSV file:",
-                validate=lambda x: Path(x).is_file() or "File not found"
+                validate=lambda x: _path_is_file(x) or "File not found"
             ).execute()
 
-        file_path = Path(source_file)
+        file_path = _expand_path(source_file)
         if not file_path.is_file():
             raise CidCritical(f"File not found: {source_file}")
 
-        cid_print(f"\n📁 Reading CSV file: {source_file}")
+        cid_print(f"\n📁 Reading CSV file: {file_path}")
 
-        # Load CSV data
-        with open(file_path, newline='', encoding='utf-8') as f:
+        # Load CSV data. utf-8-sig transparently strips a UTF-8 BOM if present
+        # (e.g. exports from AWS Organizations / Excel). With plain utf-8 the
+        # BOM sticks to the first quoted header and the embedded quotes end up
+        # in the column name, producing invalid Athena SQL later.
+        with open(file_path, newline='', encoding='utf-8-sig') as f:
             reader = csv.DictReader(f, skipinitialspace=True)
             csv_data = list(reader)
 
@@ -2136,7 +2164,7 @@ class UnifiedWorkflow:
                 for col in selected_columns
             ],
             'file_source': {
-                'path': str(source_file),
+                'path': str(file_path),
                 'account_column': 'account_id',
                 'data': transformed_data,
             },
@@ -2390,7 +2418,7 @@ class UnifiedWorkflow:
         if use_file and not source_file:
             source_file = inquirer.filepath(
                 message="Enter path to CSV file:",
-                validate=lambda x: Path(x).is_file() or "File not found"
+                validate=lambda x: _path_is_file(x) or "File not found"
             ).execute()
 
         # Configure file source if selected
@@ -2892,12 +2920,13 @@ class AthenaWriter:
         values_clause = ',\n  '.join(values_rows)
 
         # Quote column names to handle spaces, special chars, and reserved words
-        quoted_columns = [f'"{col}"' for col in columns]
+        # (escaping any embedded double quotes)
+        quoted_columns = [_quote_ident(col) for col in columns]
         column_list = ', '.join(quoted_columns)
 
         # Explicitly CAST each column to VARCHAR in the outer SELECT to handle
         # columns that are all-NULL (Athena cannot infer type from NULL alone)
-        select_parts = [f'CAST("{col}" AS VARCHAR) AS "{col}"' for col in columns]
+        select_parts = [f'CAST({_quote_ident(col)} AS VARCHAR) AS {_quote_ident(col)}' for col in columns]
         select_clause = ', '.join(select_parts)
 
         sql = f"""CREATE OR REPLACE VIEW {database}.{view_name} AS
@@ -3355,7 +3384,7 @@ SELECT {select_clause} FROM (
             dim_names = sorted(
                 {d['name'] for d in taxonomy_dimensions}, key=str.lower
             )
-            select_parts.extend(f'file."{name}"' for name in dim_names)
+            select_parts.extend(f'file.{_quote_ident(name)}' for name in dim_names)
             select_clause = ',\n    '.join(select_parts)
             return f"""CREATE OR REPLACE VIEW {database}.{view_name} AS
 SELECT
@@ -3409,19 +3438,19 @@ FROM {database}.{file_source_view} file"""
                     filter(org.hierarchytags, x -> x.key = '{source_value}'),
                     1
                 ).value"""
-                dimension_parts.append((output_name, f"{tag_expr} AS {output_name}"))
+                dimension_parts.append((output_name, f"{tag_expr} AS {_quote_ident(output_name)}"))
                     
             elif source_type == 'file':
                 if file_source_view:
-                    dimension_parts.append((output_name, f"file.{source_value} AS {output_name}"))
+                    dimension_parts.append((output_name, f"file.{_quote_ident(source_value)} AS {_quote_ident(output_name)}"))
                 else:
                     logger.warning("File source dimension %s specified but no file source view", dim_name)
-                    dimension_parts.append((output_name, f"NULL AS {output_name}"))
+                    dimension_parts.append((output_name, f"NULL AS {_quote_ident(output_name)}"))
                     
             elif source_type == 'ou_level':
                 level_index = int(source_value)
                 ou_expr = f"TRY(org.hierarchy[{level_index}].name)"
-                dimension_parts.append((output_name, f"{ou_expr} AS {output_name}"))
+                dimension_parts.append((output_name, f"{ou_expr} AS {_quote_ident(output_name)}"))
 
             elif source_type == 'name_split':
                 if isinstance(source_value, dict):
@@ -3432,10 +3461,10 @@ FROM {database}.{file_source_view} file"""
                     safe_separator = _sanitize_separator_for_sql(separator)
                     index = source_value.get('index', 0)
                     split_expr = f"split_part(org.name, '{safe_separator}', {index + 1})"
-                    dimension_parts.append((output_name, f"{split_expr} AS {output_name}"))
+                    dimension_parts.append((output_name, f"{split_expr} AS {_quote_ident(output_name)}"))
                 else:
                     logger.warning("Name split dimension %s has invalid source_value format", dim_name)
-                    dimension_parts.append((output_name, f"NULL AS {output_name}"))
+                    dimension_parts.append((output_name, f"NULL AS {_quote_ident(output_name)}"))
         
         # Sort taxonomy dimensions alphabetically by output name
         dimension_parts.sort(key=lambda x: x[0].lower())

--- a/docs/cid-cmd.md
+++ b/docs/cid-cmd.md
@@ -228,7 +228,7 @@ The command follows a six-phase workflow:
 
 During interactive configuration you choose one or more data sources for your taxonomy dimensions:
 
-**Tags from source table** — Extracts values from the `hierarchytags` column in `organization_data`. Each selected tag key becomes a column in the output view. For example, if your accounts are tagged with `Environment=Production` and `CostCenter=Engineering`, selecting those tag keys produces `environment` and `cost_center` columns.
+**Account/OU tags** — Extracts values from the `hierarchytags` column in `organization_data`. Each selected tag key becomes a column in the output view. For example, if your accounts are tagged with `Environment=Production` and `CostCenter=Engineering`, selecting those tag keys produces `environment` and `cost_center` columns.
 
 **Additional file (`--file`)** — Joins columns from a CSV/Excel/JSON file by account ID. The file must contain an account ID column; all other selected columns become taxonomy dimensions. Example file:
 ```csv
@@ -237,7 +237,7 @@ account_id,business_unit,team
 234567890123,Platform,Data
 ```
 
-**OU hierarchy level** — Extracts the organizational unit name at a given level in the account's OU hierarchy. The tool discovers available levels from your data and shows sample values. For example, if an account's hierarchy is `ROOT > Pegasus > Team-A`, selecting level 2 produces `Pegasus`. Generates SQL like `TRY(org.hierarchy[2].name)`.
+**OU name** — Extracts the organizational unit name at a given level in the account's OU hierarchy. The tool discovers available levels from your data and shows sample values. For example, if an account's hierarchy is `ROOT > Pegasus > Team-A`, selecting level 2 produces `Pegasus`. Generates SQL like `TRY(org.hierarchy[2].name)`.
 
 **Split account name** — Extracts dimensions by splitting the `account_name` string on a separator character. You specify the separator and the positional index to extract. For example, for account name `aws-retail-prod`, splitting by `-` at index 1 yields `retail`, and at index 2 yields `prod`.
 
@@ -264,7 +264,7 @@ The command saves its configuration as an Athena view (`<view_name>_config`). On
 Create an account map using AWS Organization tags:
 ```bash
 cid-cmd map
-# → Select "Tags from source table"
+# → Select "Account/OU tags"
 # → Pick tag keys like Environment, CostCenter, Team
 # → Preview and confirm
 ```
@@ -272,7 +272,7 @@ cid-cmd map
 Create an account map enriched with data from a spreadsheet:
 ```bash
 cid-cmd map --file ~/Downloads/account_taxonomy.xlsx
-# → Select "Additional file" and/or "Tags from source table"
+# → Select "Additional file" and/or "Account/OU tags"
 # → Pick columns from the file to use as dimensions
 # → Preview and confirm
 ```


### PR DESCRIPTION
*Issue #, if available:* The existing workflow checked for a source database which was not needed in case a user only wanted to use a CSV file to provide taxonomy.

*Description of changes:* Added an option for CSV only mode, renamed options for OU name & Account/OU tags as the source for taxonomy dimensions. The rename clarifies what each is referring to.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
