### PR TITLE
docs: add CloudShell upgrade note for invalid shebang issue

### DIFF
--- a/CID-CMD.md
+++ b/CID-CMD.md
@@ -25,6 +25,11 @@ CID is also provided in a form of CloudFormation templates. See detailed instruc
     pip3 install --upgrade cid-cmd
     ```
 
+    > **AWS CloudShell note:** If upgrading from a pre-installed version and `cid-cmd` fails with `cannot execute: required file not found`, run the following to regenerate the launcher with the correct interpreter:
+    > ```bash
+    > python3 -m pip install --force-reinstall cid-cmd
+    > ```
+
 #### Dashboard Deployment
 
 ```bash


### PR DESCRIPTION
## Problem

When upgrading `cid-cmd` on AWS CloudShell from a pre-installed version, `pip` does not always regenerate the console launcher, leaving it pointing at a Python interpreter path that no longer exists. This causes:

```
-bash: /home/cloudshell-user/.local/bin/cid-cmd: cannot execute: required file not found
```

## Fix

Added a CloudShell-specific note to the installation instructions documenting the `--force-reinstall` workaround that regenerates the launcher with the correct interpreter path.

Fixes #1520