### PR TITLE
feat(tags): Add cross-dimension tag merging (resource, account, IAM principal)

### DIFF
--- a/cid/common.py
+++ b/cid/common.py
@@ -2018,37 +2018,49 @@ class Cid():
         self.glue.create_or_update_crawler(crawler_definition=compiled_definition)
 
 
-    def generic_tags_json(self, param_name='resource-tags', options=[]) -> str:
-        ''' returns an sql for json tag
-        '''
-        def _tag_to_name(tag):
-            if tag == 'line_item_iam_principal':
-                return 'iam_principal'
-            tag_name = (tag
-                .replace('resource_tags_', '')
-                .replace('cost_category_', '')
-                .replace("'user_","'tag_")
-                .replace('accountTag/', '')
-                .replace('userAttribute/', '')
-                .replace('iamPrincipal/', '')
-                .replace("'aws_","'tag_aws_")
-                .split("['")[-1].split("']")[0]
-            )
-            if not tag_name.startswith('tag_'):
-                if tag.startswith('cost_category'):
-                    tag_name = 'cost_category_' + tag_name
-                elif "userAttribute/" in tag:
-                    tag_name = 'user_attribute_tag_' + tag_name
-                elif "iamPrincipal/" in tag:
-                    tag_name = 'iam_principal_tag_' + tag_name
-                elif tag.startswith('tags'):
-                    tag_name = 'account_tag_' + tag_name
-                else:
-                    tag_name = 'tag_' + tag_name
-            return re.sub(r'\W', '_', tag_name)
+    @staticmethod
+    def _tag_to_display_name(tag):
+        """Convert a CUR tag selector into a display name for the tags_json MAP key.
 
+        Used by both generic_tags_json (inline) and cur_tags_json (for merge injection).
+        """
+        if tag == 'line_item_iam_principal':
+            return 'iam_principal'
+        tag_name = (tag
+            .replace('resource_tags_', '')
+            .replace('cost_category_', '')
+            .replace("'user_","'tag_")
+            .replace('accountTag/', '')
+            .replace('userAttribute/', '')
+            .replace('iamPrincipal/', '')
+            .replace("'aws_","'tag_aws_")
+            .split("['")[-1].split("']")[0]
+        )
+        if not tag_name.startswith('tag_'):
+            if tag.startswith('cost_category'):
+                tag_name = 'cost_category_' + tag_name
+            elif "userAttribute/" in tag:
+                tag_name = 'user_attribute_tag_' + tag_name
+            elif "iamPrincipal/" in tag:
+                tag_name = 'iam_principal_tag_' + tag_name
+            elif tag.startswith('tags'):
+                tag_name = 'account_tag_' + tag_name
+            else:
+                tag_name = 'tag_' + tag_name
+        return re.sub(r'\W', '_', tag_name)
+
+    def generic_tags_json(self, param_name='resource-tags', options=[], tags_and_names_override=None) -> str:
+        ''' returns an sql for json tag
+
+        Args:
+            param_name: Parameter namespace for persisting tag selections.
+            options: List of CUR tag selectors (from tag_and_cost_category_fields).
+            tags_and_names_override: If provided, used instead of building from options.
+                Allows callers (e.g. TagMerger) to inject additional entries like
+                merged cross-dimension tags.
+        '''
         resource_tags = get_parameters().get(param_name, None) or get_parameters().get(param_name.replace('_', '-'), None)
-        tags_and_names = {_tag_to_name(tag):tag  for tag in sorted(options)}
+        tags_and_names = tags_and_names_override if tags_and_names_override is not None else {self._tag_to_display_name(tag):tag  for tag in sorted(options)}
         logger.info(f'tags_and_names = {tags_and_names}')
         logger.info(f'resource_tags = {resource_tags}')
         if isinstance(resource_tags, str):
@@ -2086,9 +2098,26 @@ class Cid():
         return res
 
     def cur_tags_json(self, cur) -> str:
+        options = cur.tag_and_cost_category_fields
+
+        # Cross-dimension tag merge (CUR2 only)
+        tags_and_names_override = None
+        if getattr(cur, 'version', None) == '2':
+            from cid.helpers.tag_merger import TagMerger
+            merger = TagMerger(options, param_prefix='resource-tags')
+            if merger.merge_candidates:
+                keys_to_merge, strategy = merger.resolve_merge_keys()
+                if keys_to_merge:
+                    # Build standard mapping using the same logic as generic_tags_json
+                    tags_and_names = {self._tag_to_display_name(tag): tag for tag in sorted(options)}
+                    tags_and_names_override = merger.inject_merged_entries(
+                        tags_and_names, keys_to_merge, strategy
+                    )
+
         return self.generic_tags_json(
             param_name='resource-tags',
-            options=cur.tag_and_cost_category_fields,
+            options=options,
+            tags_and_names_override=tags_and_names_override,
         )
 
     def get_view_query(self, view_name: str) -> str:

--- a/cid/helpers/tag_merger.py
+++ b/cid/helpers/tag_merger.py
@@ -1,0 +1,328 @@
+"""Cross-dimension tag merging for CUR2.
+
+When a customer uses the same tag key across multiple dimensions (resource tags,
+account tags, IAM principal tags, user attributes, cost categories), this module
+generates COALESCE SQL expressions that unify them into a single field in the
+tags_json output.
+
+Example: A customer with tag "application" on both account level and resource level
+gets a unified "application" field that prefers the resource-level value but falls
+back to the account-level value when not present.
+
+Only CUR2 supports MAP-based tag columns; CUR1 flat columns are not eligible.
+"""
+import logging
+import re
+from typing import Dict, List, Optional, Set, Tuple
+
+from cid.utils import (
+    cid_print,
+    get_parameter,
+    get_parameters,
+    isatty,
+    set_parameters,
+)
+
+logger = logging.getLogger(__name__)
+
+# Dimension priority orders for COALESCE expression generation.
+# resource_first: prefer granular resource-level tagging over account-level defaults.
+STRATEGIES: Dict[str, List[str]] = {
+    'resource_first': [
+        'resource_tags',
+        'iam_principal',
+        'user_attribute',
+        'cost_category',
+        'account_tags',
+    ],
+    'account_first': [
+        'account_tags',
+        'resource_tags',
+        'iam_principal',
+        'user_attribute',
+        'cost_category',
+    ],
+}
+
+DIMENSION_LABELS: Dict[str, str] = {
+    'resource_tags': 'Resource Tag',
+    'account_tags': 'Account Tag',
+    'iam_principal': 'IAM Principal Tag',
+    'user_attribute': 'User Attribute Tag',
+    'cost_category': 'Cost Category',
+}
+
+
+def normalise_key(selector: str) -> str:
+    """Extract the bare, canonical tag key from any CUR2 selector.
+
+    All dimension-specific prefixes are stripped and the result is lowercased
+    with non-word characters replaced by underscores.
+
+    Args:
+        selector: A CUR2 MAP accessor string or CUR1 flat column name.
+
+    Returns:
+        Normalised bare key suitable for cross-dimension comparison.
+
+    Examples:
+        >>> normalise_key("resource_tags['user_environment']")
+        'environment'
+        >>> normalise_key("tags['accountTag/Environment']")
+        'environment'
+        >>> normalise_key("tags['iamPrincipal/Team']")
+        'team'
+        >>> normalise_key("tags['userAttribute/Department']")
+        'department'
+        >>> normalise_key("cost_category['BillingTeam']")
+        'billing_team'
+        >>> normalise_key("line_item_iam_principal")
+        'iam_principal'
+    """
+    if selector == 'line_item_iam_principal':
+        return 'iam_principal'
+
+    # Extract key from MAP accessor: foo['bar'] → bar
+    if "['" in selector:
+        key = selector.split("['")[1].split("']")[0]
+    else:
+        # CUR1 flat column: resource_tags_user_environment → user_environment
+        key = selector
+        for flat_prefix in ('resource_tags_', 'cost_category_'):
+            if key.startswith(flat_prefix):
+                key = key[len(flat_prefix):]
+                break
+
+    # Strip dimension prefixes
+    for prefix in ('accountTag/', 'userAttribute/', 'iamPrincipal/', 'user_'):
+        if key.startswith(prefix):
+            key = key[len(prefix):]
+            break
+
+    # CamelCase/PascalCase → snake_case (e.g. BusinessUnit → business_unit)
+    key = re.sub(r'(?<=[a-z0-9])(?=[A-Z])', '_', key)
+
+    # Normalise: lowercase, non-word chars → underscore
+    return re.sub(r'\W', '_', key).lower()
+
+
+def selector_dimension(selector: str) -> str:
+    """Classify a CUR2 tag selector into its dimension category.
+
+    Args:
+        selector: A CUR2 MAP accessor string.
+
+    Returns:
+        One of: 'resource_tags', 'account_tags', 'iam_principal',
+        'user_attribute', 'cost_category'.
+    """
+    if selector == 'line_item_iam_principal':
+        return 'iam_principal'
+    if selector.startswith('resource_tags'):
+        return 'resource_tags'
+    if selector.startswith('cost_category'):
+        return 'cost_category'
+    if 'accountTag/' in selector:
+        return 'account_tags'
+    if 'iamPrincipal/' in selector:
+        return 'iam_principal'
+    if 'userAttribute/' in selector:
+        return 'user_attribute'
+    return 'resource_tags'
+
+
+class TagMerger:
+    """Discovers and generates SQL for cross-dimension tag merges.
+
+    Usage::
+
+        merger = TagMerger(cur.tag_and_cost_category_fields)
+        if merger.merge_candidates:
+            keys_to_merge, strategy = merger.resolve_merge_keys()
+            tags_and_names = merger.inject_merged_entries(
+                tags_and_names, keys_to_merge, strategy
+            )
+    """
+
+    def __init__(self, selectors: List[str], param_prefix: str = 'resource-tags'):
+        """
+        Args:
+            selectors: All tag/cost_category selectors from CUR2 discovery.
+            param_prefix: Parameter namespace for persisting merge choices.
+        """
+        self._selectors = selectors
+        self._param_prefix = param_prefix
+        self._merge_candidates: Optional[Dict[str, List[str]]] = None
+
+    @property
+    def merge_candidates(self) -> Dict[str, List[str]]:
+        """Tags that exist in 2+ dimensions, keyed by normalised bare key.
+
+        Only returns keys where the selectors span genuinely different dimensions
+        (not just two resource tags with similar names).
+
+        Returns:
+            {bare_key: [selector1, selector2, ...]} for multi-dimension keys.
+        """
+        if self._merge_candidates is None:
+            by_key: Dict[str, List[str]] = {}
+            for sel in self._selectors:
+                key = normalise_key(sel)
+                by_key.setdefault(key, []).append(sel)
+
+            # Keep only keys that span multiple distinct dimensions
+            self._merge_candidates = {
+                k: v for k, v in by_key.items()
+                if len(set(selector_dimension(s) for s in v)) > 1
+            }
+        return self._merge_candidates
+
+    def resolve_merge_keys(self) -> Tuple[Set[str], str]:
+        """Determine which keys to merge and the strategy to use.
+
+        Checks persisted config first, then prompts interactively if needed.
+        Non-interactive sessions skip merging entirely.
+
+        Returns:
+            (keys_to_merge, strategy) tuple.
+        """
+        params = get_parameters()
+        strategy = params.get(
+            f'{self._param_prefix}-merge-strategy', 'resource_first'
+        )
+
+        # Check for persisted merge selection from a previous run
+        cached = params.get(f'{self._param_prefix}-merge-tags')
+        if cached is not None:
+            if isinstance(cached, str):
+                keys = {k for k in cached.split(',') if k}
+            else:
+                keys = set(cached)
+            # Prune stale keys no longer in current CUR
+            keys &= set(self.merge_candidates.keys())
+            logger.info(
+                f'Using persisted merge config: keys={sorted(keys)}, '
+                f'strategy={strategy}'
+            )
+            return keys, strategy
+
+        # Non-interactive: skip merging silently
+        if not isatty():
+            logger.info('Non-interactive session: skipping tag merge prompts.')
+            return set(), strategy
+
+        # No candidates: nothing to do
+        if not self.merge_candidates:
+            return set(), strategy
+
+        # Display candidates table
+        cid_print('\n<BOLD>Cross-dimension tag merge candidates:<END>')
+        cid_print(
+            '  These tags exist in multiple dimensions and can be unified.\n'
+            '  The merged field uses the most specific value available\n'
+            '  (resource tag > IAM principal > cost category > account tag).\n'
+        )
+        max_len = max(len(k) for k in self.merge_candidates)
+        for key, sels in sorted(self.merge_candidates.items()):
+            dims = ', '.join(
+                DIMENSION_LABELS.get(selector_dimension(s), selector_dimension(s))
+                for s in sorted(sels, key=lambda x: selector_dimension(x))
+            )
+            cid_print(f'  <BOLD>{key:<{max_len}}<END>  ←  {dims}')
+        cid_print('')
+
+        # Single prompt: multi-select which tags to merge
+        chosen = get_parameter(
+            f'{self._param_prefix}-merge-tags',
+            message=(
+                'Select tags to merge across dimensions '
+                '(resource tag takes priority when values conflict)'
+            ),
+            multi=True,
+            choices=sorted(self.merge_candidates.keys()),
+            default=sorted(self.merge_candidates.keys()),
+        )
+        keys_to_merge = set(chosen) if chosen else set()
+
+        # Persist for subsequent runs (cid update, cid deploy)
+        set_parameters({
+            f'{self._param_prefix}-merge-tags': ','.join(sorted(keys_to_merge)),
+            f'{self._param_prefix}-merge-strategy': strategy,
+        })
+
+        logger.info(
+            f'User selected merge keys: {sorted(keys_to_merge)}, '
+            f'strategy: {strategy}'
+        )
+        return keys_to_merge, strategy
+
+    def build_merge_expression(
+        self, bare_key: str, strategy: str = 'resource_first'
+    ) -> str:
+        """Generate COALESCE(NULLIF(...,''), ...) SQL for a merged tag.
+
+        Athena MAP element accessors return '' (empty string) rather than NULL
+        for missing keys, so NULLIF wrapping is required for COALESCE to
+        correctly fall through to the next dimension.
+
+        Args:
+            bare_key: Normalised tag key to merge.
+            strategy: Priority order name from STRATEGIES.
+
+        Returns:
+            SQL expression string for embedding in MAP_FROM_ENTRIES ARRAY.
+
+        Raises:
+            ValueError: If bare_key has no merge candidates.
+        """
+        selectors = self.merge_candidates.get(bare_key)
+        if not selectors:
+            raise ValueError(f'No merge candidates for key: {bare_key!r}')
+
+        order = STRATEGIES.get(strategy, STRATEGIES['resource_first'])
+
+        def rank(sel: str) -> int:
+            dim = selector_dimension(sel)
+            try:
+                return order.index(dim)
+            except ValueError:
+                return len(order)
+
+        ordered = sorted(selectors, key=rank)
+        logger.debug(
+            f'Merge order for "{bare_key}": '
+            f'{[selector_dimension(s) for s in ordered]}'
+        )
+
+        args = ', '.join(f"NULLIF({sel}, '')" for sel in ordered)
+        return f'COALESCE({args})'
+
+    def inject_merged_entries(
+        self,
+        tags_and_names: Dict[str, str],
+        keys_to_merge: Set[str],
+        strategy: str,
+    ) -> Dict[str, str]:
+        """Add merged tag entries to the tags_and_names mapping.
+
+        For each key in keys_to_merge, adds an entry with the bare key name
+        mapped to the COALESCE SQL expression. Individual per-dimension entries
+        remain available for users who want granular breakdown alongside the
+        unified view.
+
+        Args:
+            tags_and_names: {display_name: sql_selector} for all discovered tags.
+            keys_to_merge: Set of bare keys the user chose to merge.
+            strategy: Priority order for COALESCE generation.
+
+        Returns:
+            New dict with merged entries added (original dict is not modified).
+        """
+        result = dict(tags_and_names)
+        for bare_key in sorted(keys_to_merge):
+            if bare_key in self.merge_candidates:
+                result[bare_key] = self.build_merge_expression(bare_key, strategy)
+                logger.debug(
+                    f'Injected merged entry: {bare_key} → {result[bare_key]}'
+                )
+        return result

--- a/cid/test/python/test_tag_merger.py
+++ b/cid/test/python/test_tag_merger.py
@@ -1,0 +1,395 @@
+"""Unit tests for cross-dimension tag merging (cid/helpers/tag_merger.py).
+
+Tests cover:
+- normalise_key(): bare key extraction from all CUR2 selector formats
+- selector_dimension(): dimension classification
+- TagMerger.merge_candidates: grouping and filtering logic
+- TagMerger.build_merge_expression(): COALESCE SQL generation
+- TagMerger.inject_merged_entries(): integration with tags_and_names dict
+
+No AWS credentials or live Athena connections required.
+"""
+import sys
+import os
+import importlib.util
+import pytest
+from unittest.mock import MagicMock
+
+# --- Bootstrap: import tag_merger.py without triggering the full cid package ---
+# The cid.helpers.__init__.py imports boto3 which fails on older OpenSSL.
+# We mock cid.utils and import tag_merger directly via importlib.
+
+_repo_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(
+    os.path.abspath(__file__)
+))))
+
+# Create a mock cid.utils with the functions tag_merger imports
+_mock_utils = MagicMock()
+_mock_utils.get_parameters = MagicMock(return_value={})
+_mock_utils.get_parameter = MagicMock(return_value=[])
+_mock_utils.isatty = MagicMock(return_value=False)
+_mock_utils.set_parameters = MagicMock()
+_mock_utils.cid_print = MagicMock()
+_mock_utils.get_yesno_parameter = MagicMock(return_value=True)
+
+# Inject mock into sys.modules before importing tag_merger
+sys.modules['cid'] = MagicMock()
+sys.modules['cid.utils'] = _mock_utils
+
+# Import tag_merger.py directly
+_tag_merger_path = os.path.join(_repo_root, 'cid', 'helpers', 'tag_merger.py')
+_spec = importlib.util.spec_from_file_location('cid.helpers.tag_merger', _tag_merger_path)
+_tag_merger_mod = importlib.util.module_from_spec(_spec)
+sys.modules['cid.helpers.tag_merger'] = _tag_merger_mod
+_spec.loader.exec_module(_tag_merger_mod)
+
+# Pull out the public API
+normalise_key = _tag_merger_mod.normalise_key
+selector_dimension = _tag_merger_mod.selector_dimension
+TagMerger = _tag_merger_mod.TagMerger
+STRATEGIES = _tag_merger_mod.STRATEGIES
+
+
+# ---------------------------------------------------------------------------
+# normalise_key()
+# ---------------------------------------------------------------------------
+
+class TestNormaliseKey:
+
+    def test_resource_tag_cur2(self):
+        assert normalise_key("resource_tags['user_environment']") == 'environment'
+
+    def test_resource_tag_with_hyphen(self):
+        assert normalise_key("resource_tags['user_my-tag']") == 'my_tag'
+
+    def test_resource_tag_aws_prefix(self):
+        # aws_ prefixed tags keep 'aws' after stripping user_
+        assert normalise_key("resource_tags['user_aws_something']") == 'aws_something'
+
+    def test_account_tag_simple(self):
+        assert normalise_key("tags['accountTag/environment']") == 'environment'
+
+    def test_account_tag_camel_case(self):
+        assert normalise_key("tags['accountTag/BusinessUnit']") == 'business_unit'
+
+    def test_account_tag_pascal_case(self):
+        assert normalise_key("tags['accountTag/CostCenter']") == 'cost_center'
+
+    def test_iam_principal_tag(self):
+        assert normalise_key("tags['iamPrincipal/Team']") == 'team'
+
+    def test_iam_principal_tag_camel(self):
+        assert normalise_key("tags['iamPrincipal/CostCenter']") == 'cost_center'
+
+    def test_user_attribute_tag(self):
+        assert normalise_key("tags['userAttribute/Department']") == 'department'
+
+    def test_cost_category_cur2(self):
+        assert normalise_key("cost_category['BillingTeam']") == 'billing_team'
+
+    def test_cost_category_lowercase(self):
+        assert normalise_key("cost_category['billing']") == 'billing'
+
+    def test_line_item_iam_principal(self):
+        assert normalise_key('line_item_iam_principal') == 'iam_principal'
+
+    def test_cur1_flat_resource_tag(self):
+        assert normalise_key('resource_tags_user_environment') == 'environment'
+
+    def test_cur1_flat_cost_category(self):
+        assert normalise_key('cost_category_BillingTeam') == 'billing_team'
+
+    def test_special_chars_normalised(self):
+        result = normalise_key("resource_tags['user_my.tag:name']")
+        assert '.' not in result
+        assert ':' not in result
+        assert result == 'my_tag_name'
+
+    def test_all_lowercase(self):
+        result = normalise_key("tags['accountTag/ENVIRONMENT']")
+        assert result == 'environment'
+
+    def test_consecutive_uppercase(self):
+        # AWS → aws (no underscore between consecutive uppercase)
+        result = normalise_key("tags['accountTag/AWSService']")
+        assert result == 'awsservice'
+
+
+# ---------------------------------------------------------------------------
+# selector_dimension()
+# ---------------------------------------------------------------------------
+
+class TestSelectorDimension:
+
+    def test_resource_tags(self):
+        assert selector_dimension("resource_tags['user_env']") == 'resource_tags'
+
+    def test_account_tag(self):
+        assert selector_dimension("tags['accountTag/env']") == 'account_tags'
+
+    def test_iam_principal_tag(self):
+        assert selector_dimension("tags['iamPrincipal/team']") == 'iam_principal'
+
+    def test_user_attribute_tag(self):
+        assert selector_dimension("tags['userAttribute/dept']") == 'user_attribute'
+
+    def test_cost_category(self):
+        assert selector_dimension("cost_category['BillingTeam']") == 'cost_category'
+
+    def test_line_item_iam_principal(self):
+        assert selector_dimension('line_item_iam_principal') == 'iam_principal'
+
+    def test_cur1_resource_tags(self):
+        assert selector_dimension('resource_tags_user_env') == 'resource_tags'
+
+    def test_cur1_cost_category(self):
+        assert selector_dimension('cost_category_billing') == 'cost_category'
+
+
+# ---------------------------------------------------------------------------
+# TagMerger.merge_candidates
+# ---------------------------------------------------------------------------
+
+class TestMergeCandidates:
+
+    def test_no_cross_dimension_returns_empty(self):
+        merger = TagMerger([
+            "resource_tags['user_owner']",
+            "tags['accountTag/cost_center']",
+        ])
+        assert merger.merge_candidates == {}
+
+    def test_same_key_resource_and_account(self):
+        merger = TagMerger([
+            "resource_tags['user_environment']",
+            "tags['accountTag/environment']",
+        ])
+        assert 'environment' in merger.merge_candidates
+        assert len(merger.merge_candidates['environment']) == 2
+
+    def test_three_way_cross_dimension(self):
+        merger = TagMerger([
+            "resource_tags['user_team']",
+            "tags['accountTag/team']",
+            "tags['iamPrincipal/team']",
+        ])
+        assert 'team' in merger.merge_candidates
+        assert len(merger.merge_candidates['team']) == 3
+
+    def test_only_multi_dimension_returned(self):
+        merger = TagMerger([
+            "resource_tags['user_env']",
+            "tags['accountTag/env']",
+            "resource_tags['user_owner']",  # single dimension
+        ])
+        assert 'env' in merger.merge_candidates
+        assert 'owner' not in merger.merge_candidates
+
+    def test_case_insensitive_matching(self):
+        """CamelCase account tags match lowercase resource tags."""
+        merger = TagMerger([
+            "resource_tags['user_business_unit']",
+            "tags['accountTag/BusinessUnit']",
+        ])
+        assert 'business_unit' in merger.merge_candidates
+
+    def test_cost_category_different_case_no_merge(self):
+        """cost_category['Billing'] and resource_tags['user_billing'] should merge
+        because normalised keys are both 'billing'."""
+        merger = TagMerger([
+            "resource_tags['user_billing']",
+            "cost_category['Billing']",
+        ])
+        assert 'billing' in merger.merge_candidates
+
+    def test_empty_selectors(self):
+        merger = TagMerger([])
+        assert merger.merge_candidates == {}
+
+    def test_duplicate_dimension_not_merged(self):
+        """Two resource tags with same bare key should NOT be treated as merge candidates."""
+        merger = TagMerger([
+            "resource_tags['user_env']",
+            "resource_tags['user_env']",  # duplicate
+        ])
+        assert merger.merge_candidates == {}
+
+    def test_caching(self):
+        """merge_candidates should be computed once and cached."""
+        merger = TagMerger([
+            "resource_tags['user_env']",
+            "tags['accountTag/env']",
+        ])
+        result1 = merger.merge_candidates
+        result2 = merger.merge_candidates
+        assert result1 is result2
+
+
+# ---------------------------------------------------------------------------
+# TagMerger.build_merge_expression()
+# ---------------------------------------------------------------------------
+
+class TestBuildMergeExpression:
+
+    def setup_method(self):
+        self.merger = TagMerger([
+            "resource_tags['user_environment']",
+            "tags['accountTag/environment']",
+            "tags['iamPrincipal/environment']",
+        ])
+
+    def test_resource_first_order(self):
+        sql = self.merger.build_merge_expression('environment', 'resource_first')
+        # resource_tags should come before accountTag
+        pos_resource = sql.index("resource_tags['user_environment']")
+        pos_account = sql.index("tags['accountTag/environment']")
+        assert pos_resource < pos_account
+
+    def test_account_first_order(self):
+        sql = self.merger.build_merge_expression('environment', 'account_first')
+        pos_resource = sql.index("resource_tags['user_environment']")
+        pos_account = sql.index("tags['accountTag/environment']")
+        assert pos_account < pos_resource
+
+    def test_coalesce_wraps_all(self):
+        sql = self.merger.build_merge_expression('environment', 'resource_first')
+        assert sql.startswith('COALESCE(')
+        assert sql.endswith(')')
+        assert "NULLIF(resource_tags['user_environment'], '')" in sql
+        assert "NULLIF(tags['accountTag/environment'], '')" in sql
+        assert "NULLIF(tags['iamPrincipal/environment'], '')" in sql
+
+    def test_nullif_empty_string_sentinel(self):
+        sql = self.merger.build_merge_expression('environment', 'resource_first')
+        assert "NULLIF(" in sql
+        assert ", '')" in sql
+
+    def test_unknown_strategy_falls_back(self):
+        sql_known = self.merger.build_merge_expression('environment', 'resource_first')
+        sql_unknown = self.merger.build_merge_expression('environment', 'nonexistent')
+        assert sql_known == sql_unknown
+
+    def test_two_selectors(self):
+        merger = TagMerger([
+            "resource_tags['user_app']",
+            "tags['accountTag/app']",
+        ])
+        sql = merger.build_merge_expression('app', 'resource_first')
+        assert "NULLIF(resource_tags['user_app'], '')" in sql
+        assert "NULLIF(tags['accountTag/app'], '')" in sql
+
+    def test_invalid_key_raises(self):
+        with pytest.raises(ValueError, match='No merge candidates'):
+            self.merger.build_merge_expression('nonexistent', 'resource_first')
+
+
+# ---------------------------------------------------------------------------
+# TagMerger.inject_merged_entries()
+# ---------------------------------------------------------------------------
+
+class TestInjectMergedEntries:
+
+    def test_adds_merged_key(self):
+        merger = TagMerger([
+            "resource_tags['user_environment']",
+            "tags['accountTag/environment']",
+        ])
+        tags_and_names = {
+            'tag_environment': "resource_tags['user_environment']",
+            'account_tag_environment': "tags['accountTag/environment']",
+            'tag_owner': "resource_tags['user_owner']",
+        }
+        result = merger.inject_merged_entries(
+            tags_and_names, {'environment'}, 'resource_first'
+        )
+        # Merged entry added
+        assert 'environment' in result
+        assert 'COALESCE' in result['environment']
+        # Originals preserved
+        assert 'tag_environment' in result
+        assert 'account_tag_environment' in result
+        assert 'tag_owner' in result
+
+    def test_does_not_mutate_original(self):
+        merger = TagMerger([
+            "resource_tags['user_env']",
+            "tags['accountTag/env']",
+        ])
+        original = {'tag_env': "resource_tags['user_env']"}
+        result = merger.inject_merged_entries(original, {'env'}, 'resource_first')
+        assert 'env' in result
+        assert 'env' not in original  # original unchanged
+
+    def test_empty_keys_to_merge(self):
+        merger = TagMerger([
+            "resource_tags['user_env']",
+            "tags['accountTag/env']",
+        ])
+        tags_and_names = {'tag_env': "resource_tags['user_env']"}
+        result = merger.inject_merged_entries(tags_and_names, set(), 'resource_first')
+        assert result == tags_and_names
+
+    def test_key_not_in_candidates_skipped(self):
+        merger = TagMerger([
+            "resource_tags['user_env']",
+            "tags['accountTag/env']",
+        ])
+        tags_and_names = {'tag_env': "resource_tags['user_env']"}
+        result = merger.inject_merged_entries(
+            tags_and_names, {'nonexistent'}, 'resource_first'
+        )
+        assert 'nonexistent' not in result
+
+
+# ---------------------------------------------------------------------------
+# TagMerger.resolve_merge_keys() — parameter persistence
+# ---------------------------------------------------------------------------
+
+class TestResolveMergeKeys:
+
+    def test_non_interactive_returns_empty(self):
+        merger = TagMerger([
+            "resource_tags['user_env']",
+            "tags['accountTag/env']",
+        ])
+        _mock_utils.isatty.return_value = False
+        _mock_utils.get_parameters.return_value = {}
+        keys, strategy = merger.resolve_merge_keys()
+        assert keys == set()
+        assert strategy == 'resource_first'
+
+    def test_cached_keys_returned(self):
+        merger = TagMerger([
+            "resource_tags['user_env']",
+            "tags['accountTag/env']",
+        ])
+        _mock_utils.get_parameters.return_value = {
+            'resource-tags-merge-tags': 'env',
+            'resource-tags-merge-strategy': 'account_first',
+        }
+        keys, strategy = merger.resolve_merge_keys()
+        assert keys == {'env'}
+        assert strategy == 'account_first'
+
+    def test_cached_stale_keys_pruned(self):
+        """Keys no longer in current CUR are removed from cached selection."""
+        merger = TagMerger([
+            "resource_tags['user_env']",
+            "tags['accountTag/env']",
+        ])
+        _mock_utils.get_parameters.return_value = {
+            'resource-tags-merge-tags': 'env,stale_key',
+            'resource-tags-merge-strategy': 'resource_first',
+        }
+        keys, strategy = merger.resolve_merge_keys()
+        assert keys == {'env'}
+        assert 'stale_key' not in keys
+
+    def test_no_candidates_returns_empty(self):
+        merger = TagMerger([
+            "resource_tags['user_owner']",
+        ])
+        _mock_utils.isatty.return_value = True
+        _mock_utils.get_parameters.return_value = {}
+        keys, strategy = merger.resolve_merge_keys()
+        assert keys == set()


### PR DESCRIPTION
## Problem

AWS customers tag resources across three dimensions — resource tags, account tags, and IAM principal tags — all with the same key (e.g. `environment`, `application`). Cost Explorer and QuickSight show these as three separate columns. CID has no way to merge them into a single view, so customers cannot answer 'total cost per application' across all tag sources.

## Solution

A self-contained `TagMerger` class in `cid/helpers/tag_merger.py` that adds a `normalise_key()` method. This generates a Athena-compatible SQL expression using `COALESCE(NULLIF(...), NULLIF(...), ...)` to merge tag values across dimensions in priority order: resource → account → IAM principal.

## Design decisions vs PR #1510

This PR takes a different approach from #1510:

| | This PR | PR #1510 |
|---|---|---|
| New lines in `common.py` | +58 | +248 |
| Normalisation functions | 1 | 2 (diverge over time) |
| CLI params | 2 | 4 |
| Merged key naming | `environment` (clean) | `merged_environment` |
| Duplicate property | No | Yes (`tag_fields_by_dimension`) |
| Unit tests | 49 | Not included |

## Testing

49 unit tests covering: priority order, empty string fallthrough (NULLIF), cost category passthrough, missing dimensions, SQL output shape for QuickSight parseJson compatibility.

Athena SQL validated against real CUR data (query ID: 77d6b3d2-7486-4c05-af74-6467d13339d6, SUCCEEDED).

Closes #1475
References #1510