### PR TITLE
feat(summary_view): Make retention window configurable

### DIFF
--- a/cid/builtin/core/data/queries/cid/summary_view.sql
+++ b/cid/builtin/core/data/queries/cid/summary_view.sql
@@ -89,7 +89,7 @@
   FROM
     "${cur2_database}"."${cur2_table_name}"
   WHERE
-    (("bill_billing_period_start_date" >= ("date_trunc"('month', current_timestamp) - INTERVAL  '7' MONTH))
-    AND (CAST("concat"("billing_period", '-01') AS date) >= ("date_trunc"('month', current_date) - INTERVAL  '7' MONTH))
+    (("bill_billing_period_start_date" >= ("date_trunc"('month', current_timestamp) - INTERVAL  '${retention_months}' MONTH))
+    AND (CAST("concat"("billing_period", '-01') AS date) >= ("date_trunc"('month', current_date) - INTERVAL  '${retention_months}' MONTH))
     AND coalesce("line_item_operation", '') NOT IN ('EKSPod-EC2','ECSTask-EC2'))
   GROUP BY 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35

--- a/cid/builtin/core/data/resources.yaml
+++ b/cid/builtin/core/data/resources.yaml
@@ -501,6 +501,10 @@ views:
 
   summary_view:
     File: queries/cid/summary_view.sql
+    parameters:
+      retention_months:
+        default: '7'
+        description: "Number of months of billing data to include in summary_view (default: 7)"
     dependsOn:
       views:
         - cur2_view


### PR DESCRIPTION
## Description

Replaces the hardcoded `INTERVAL '7' MONTH` in `summary_view.sql` (lines 92-93) with a `${retention_months}` substitution parameter that defaults to `7`.

Customers who retain more than 7 months of CUR data (e.g. 36 months for annual analysis) can now configure the retention window during deployment without forking the SQL file.

## Changes

- `cid/builtin/core/data/queries/cid/summary_view.sql`: Replace hardcoded `'7'` with `${retention_months}`
- `cid/builtin/core/data/resources.yaml`: Add `retention_months` parameter with default `'7'` to the summary_view definition

## Backward Compatibility

Default value is `7`, preserving existing behavior for all current deployments. No action required from existing users.

Fixes #1529