### PR TITLE
fix: propagate selected Glue Data Catalog to dataset templates and IAM policies

### DIFF
--- a/cid/builtin/core/data/datasets/co/dataset.json
+++ b/cid/builtin/core/data/datasets/co/dataset.json
@@ -104,7 +104,7 @@
     "PhysicalTableMap": {
         "22291301-8e81-41bf-9270-56eb59692e55": {
             "RelationalTable": {
-                "Catalog": "AwsDataCatalog",
+                "Catalog": "${athena_catalog_name}",
                 "DataSourceArn": "${athena_datasource_arn}",
                 "Schema": "${athena_database_name}",
                 "Name": "compute_optimizer_all_options",
@@ -230,7 +230,7 @@
         },
         "5da8f118-fdc0-47ee-aaa0-b633cbf8f9c9": {
             "RelationalTable": {
-                "Catalog": "AwsDataCatalog",
+                "Catalog": "${athena_catalog_name}",
                 "DataSourceArn": "${athena_datasource_arn}",
                 "Schema": "${athena_database_name}",
                 "Name": "business_units_map",

--- a/cid/builtin/core/data/datasets/kpi/kpi_ebs_snap.json
+++ b/cid/builtin/core/data/datasets/kpi/kpi_ebs_snap.json
@@ -5,7 +5,7 @@
     "88cab3bf-bb23-4b37-9ff6-6f32e4c3d9d8": {
       "RelationalTable": {
         "DataSourceArn": "${athena_datasource_arn}",
-        "Catalog": "AwsDataCatalog",
+        "Catalog": "${athena_catalog_name}",
         "Schema": "${athena_database_name}",
         "Name": "account_map",
         "InputColumns": [
@@ -25,6 +25,7 @@
     "f224e706-8cd3-4c2f-b4e8-d8470368782f": {
       "RelationalTable": {
         "DataSourceArn": "${athena_datasource_arn}",
+        "Catalog": "${athena_catalog_name}",
         "Schema": "${athena_database_name}",
         "Name": "kpi_ebs_snap",
         "InputColumns": [

--- a/cid/builtin/core/data/datasets/kpi/kpi_ebs_storage_all.json
+++ b/cid/builtin/core/data/datasets/kpi/kpi_ebs_storage_all.json
@@ -5,6 +5,7 @@
     "23c71fa5-4992-4c85-b267-07d05b4eb69b": {
       "RelationalTable": {
         "DataSourceArn": "${athena_datasource_arn}",
+        "Catalog": "${athena_catalog_name}",
         "Schema": "${athena_database_name}",
         "Name": "kpi_ebs_storage_all",
         "InputColumns": [
@@ -127,7 +128,7 @@
     "561b26dc-d85d-4523-a17b-939ac4f261ef": {
       "RelationalTable": {
         "DataSourceArn": "${athena_datasource_arn}",
-        "Catalog": "AwsDataCatalog",
+        "Catalog": "${athena_catalog_name}",
         "Schema": "${athena_database_name}",
         "Name": "account_map",
         "InputColumns": [

--- a/cid/builtin/core/data/datasets/kpi/kpi_instance_all.json
+++ b/cid/builtin/core/data/datasets/kpi/kpi_instance_all.json
@@ -5,7 +5,7 @@
     "22881e79-6d20-4794-b50c-c96e002eee9f": {
       "RelationalTable": {
         "DataSourceArn": "${athena_datasource_arn}",
-        "Catalog": "AwsDataCatalog",
+        "Catalog": "${athena_catalog_name}",
         "Schema": "${athena_database_name}",
         "Name": "account_map",
         "InputColumns": [
@@ -25,6 +25,7 @@
     "958b7222-e3e2-41ab-8093-6ba24c5e88a1": {
       "RelationalTable": {
         "DataSourceArn": "${athena_datasource_arn}",
+        "Catalog": "${athena_catalog_name}",
         "Schema": "${athena_database_name}",
         "Name": "kpi_instance_all",
         "InputColumns": [

--- a/cid/builtin/core/data/datasets/kpi/kpi_s3_storage_all.json
+++ b/cid/builtin/core/data/datasets/kpi/kpi_s3_storage_all.json
@@ -5,6 +5,7 @@
     "99dd8380-97f3-4a26-b32c-79446aafb95e": {
       "RelationalTable": {
         "DataSourceArn": "${athena_datasource_arn}",
+        "Catalog": "${athena_catalog_name}",
         "Schema": "${athena_database_name}",
         "Name": "kpi_s3_storage_all",
         "InputColumns": [
@@ -276,7 +277,7 @@
     "a6f3d2ae-e474-4b5a-9bd2-ab3787318351": {
       "RelationalTable": {
         "DataSourceArn": "${athena_datasource_arn}",
-        "Catalog": "AwsDataCatalog",
+        "Catalog": "${athena_catalog_name}",
         "Schema": "${athena_database_name}",
         "Name": "account_map",
         "InputColumns": [

--- a/cid/builtin/core/data/datasets/kpi/kpi_tracker.json
+++ b/cid/builtin/core/data/datasets/kpi/kpi_tracker.json
@@ -5,7 +5,7 @@
     "c5460ad4-147d-4cb0-8a7e-7fc9c5f82ca4": {
       "RelationalTable": {
         "DataSourceArn": "${athena_datasource_arn}",
-        "Catalog": "AwsDataCatalog",
+        "Catalog": "${athena_catalog_name}",
         "Schema": "${athena_database_name}",
         "Name": "account_map",
         "InputColumns": [
@@ -25,6 +25,7 @@
     "ca597aad-1079-4c11-a5ac-7d9deb38132a": {
       "RelationalTable": {
         "DataSourceArn": "${athena_datasource_arn}",
+        "Catalog": "${athena_catalog_name}",
         "Schema": "${athena_database_name}",
         "Name": "kpi_tracker",
         "InputColumns": [

--- a/cid/common.py
+++ b/cid/common.py
@@ -1491,6 +1491,7 @@ class Cid():
                     workgroup=self.athena.WorkGroup,
                     buckets=buckets,
                     output_location_bucket = self.athena.workgroup_output_location().split('/')[2],
+                    catalog_name=self.athena.CatalogName,
                 )
                 cid_print(f'Role {role_name} was updated. https://console.aws.amazon.com/iam/home?#/roles/details/{role_name}')
                 role_arn = self.iam.get_role_arn(role_name)
@@ -1644,6 +1645,7 @@ class Cid():
         columns_tpl = {
             'athena_datasource_arn': athena_datasource.arn,
             'athena_database_name': self.athena.DatabaseName,
+            'athena_catalog_name': self.athena.CatalogName,
             'cur_database':    self.cur1.database   if cur1_required else None, # for backward compatibly
             'cur_table_name':  self.cur1.table_name if cur1_required else None, # for backward compatibly
             'cur1_database':   self.cur1.database   if cur1_required else None,

--- a/cid/export.py
+++ b/cid/export.py
@@ -170,6 +170,7 @@ def export_analysis(qs, athena, glue):
                 and 'Schema' in value['RelationalTable']:
                 logger.debug(f"Dataset {dataset.raw['DataSetId']} looks like classic athena dataset")
                 value['RelationalTable']['DataSourceArn'] = '${athena_datasource_arn}'
+                value['RelationalTable']['Catalog'] = '${athena_catalog_name}'
                 database_name = value['RelationalTable']['Schema']
                 discovered_databases = list(set([d for _, d in all_views_and_databases])) # default database is the first one
                 if not discovered_databases or discovered_databases[0] == database_name:

--- a/cid/helpers/iam.py
+++ b/cid/helpers/iam.py
@@ -151,7 +151,7 @@ class IAM(CidBase):
             policy_merge_mode='MERGE_RESOURCES',
             managed_policies=[]
         )
-    def ensure_data_source_role_exists(self, role_name, databases, workgroup, kms_key_arns='', buckets=[], output_location_bucket=None):
+    def ensure_data_source_role_exists(self, role_name, databases, workgroup, kms_key_arns='', buckets=[], output_location_bucket=None, catalog_name='AwsDataCatalog'):
         ''' Create or update a role specifically for a QS Datasource
         '''
         return self.ensure_role_with_policy(
@@ -215,7 +215,7 @@ class IAM(CidBase):
                                 "athena:GetWorkGroup"
                             ],
                             "Resource": [
-                                f"arn:{self.partition}:athena:{self.region}:{self.account_id}:datacatalog/AwsDataCatalog", # TODO: check if this can be variable?
+                                f"arn:{self.partition}:athena:{self.region}:{self.account_id}:datacatalog/{catalog_name}",
                                 f"arn:{self.partition}:athena:{self.region}:{self.account_id}:workgroup/{workgroup}",
                             ]
                         },

--- a/cid/test/python/test_bug_catalog_selection.py
+++ b/cid/test/python/test_bug_catalog_selection.py
@@ -1,0 +1,277 @@
+"""
+Bug Condition Exploration Test: Selected Catalog Ignored in Dataset Creation
+
+**Validates: Requirements 1.1, 1.2, 1.3, 1.4**
+
+Property 1: Bug Condition - Selected Catalog Ignored in Dataset Creation
+
+This test validates the fix is in place. It verifies that when a non-default catalog is selected:
+1. `columns_tpl` includes `athena_catalog_name` with the selected catalog value
+2. Compiled JSON datasets use the selected catalog in RelationalTable.Catalog
+3. YAML dashboard definitions use the selected catalog in RelationalTable.Catalog
+4. IAM policy resource ARN references the selected catalog (not hardcoded AwsDataCatalog)
+5. Export logic templatizes the Catalog field to ${athena_catalog_name}
+"""
+import json
+import os
+import re
+from string import Template
+
+import yaml
+import pytest
+from hypothesis import given, settings, assume, HealthCheck
+from hypothesis import strategies as st
+
+
+# Project root for locating dataset templates and YAML dashboards
+PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', '..'))
+DATASETS_DIR = os.path.join(PROJECT_ROOT, 'cid', 'builtin', 'core', 'data', 'datasets')
+DASHBOARDS_DIR = os.path.join(PROJECT_ROOT, 'dashboards')
+
+
+# Strategy: Generate non-default catalog names that start with a letter
+# (avoids YAML interpreting purely numeric strings as integers)
+catalog_name_strategy = st.from_regex(
+    r'[A-Z][A-Za-z0-9_-]{2,29}', fullmatch=True
+).filter(lambda x: x != 'AwsDataCatalog')
+
+
+class TestBugCondition_ColumnsTPLMissingCatalog:
+    """Test that columns_tpl dictionary includes athena_catalog_name.
+
+    This test reads the actual cid/common.py source to verify the fix is in place.
+    """
+
+    @given(catalog_name=catalog_name_strategy)
+    @settings(max_examples=10, suppress_health_check=[HealthCheck.function_scoped_fixture])
+    def test_columns_tpl_contains_athena_catalog_name(self, catalog_name):
+        """
+        **Validates: Requirements 1.2**
+
+        The columns_tpl dictionary in cid/common.py MUST contain an
+        'athena_catalog_name' key that references self.athena.CatalogName.
+        """
+        # Read the actual cid/common.py source code
+        common_py_path = os.path.join(PROJECT_ROOT, 'cid', 'common.py')
+        with open(common_py_path, 'r') as f:
+            source = f.read()
+
+        # Verify that 'athena_catalog_name' is present in the columns_tpl definition
+        assert "'athena_catalog_name'" in source, (
+            "cid/common.py does not contain 'athena_catalog_name' key in columns_tpl. "
+            f"Selected catalog '{catalog_name}' would be ignored during template substitution."
+        )
+
+        # Verify it references self.athena.CatalogName
+        assert 'self.athena.CatalogName' in source, (
+            "cid/common.py does not reference self.athena.CatalogName. "
+            "The athena_catalog_name template variable is not bound to the selected catalog."
+        )
+
+        # Verify the specific pattern: 'athena_catalog_name': self.athena.CatalogName
+        pattern = r"'athena_catalog_name'\s*:\s*self\.athena\.CatalogName"
+        assert re.search(pattern, source), (
+            "cid/common.py does not have 'athena_catalog_name': self.athena.CatalogName "
+            "in the columns_tpl dictionary."
+        )
+
+
+class TestBugCondition_JSONDatasetTemplatesHardcodedCatalog:
+    """Test that JSON dataset templates use template variable for Catalog field.
+
+    This test loads the 6 specific JSON dataset files that were fixed and verifies
+    that RelationalTable definitions use ${athena_catalog_name} instead of
+    hardcoded 'AwsDataCatalog'.
+    """
+
+    # Only check the 6 specific files that were in scope for the fix
+    FIXED_JSON_FILES = [
+        'co/dataset.json',
+        'kpi/kpi_instance_all.json',
+        'kpi/kpi_tracker.json',
+        'kpi/kpi_ebs_storage_all.json',
+        'kpi/kpi_ebs_snap.json',
+        'kpi/kpi_s3_storage_all.json',
+    ]
+
+    @given(catalog_name=catalog_name_strategy)
+    @settings(max_examples=5, suppress_health_check=[HealthCheck.function_scoped_fixture])
+    def test_json_templates_use_catalog_variable(self, catalog_name):
+        """
+        **Validates: Requirements 1.3, 1.4**
+
+        For any non-default catalog, after template substitution, all
+        RelationalTable.Catalog fields in the 6 fixed JSON datasets MUST
+        equal the selected catalog.
+        """
+        for relative_file in self.FIXED_JSON_FILES:
+            json_file = os.path.join(DATASETS_DIR, relative_file)
+            assert os.path.exists(json_file), f"Expected file not found: {relative_file}"
+
+            with open(json_file, 'r') as f:
+                template_text = f.read()
+
+            # Build columns_tpl with the non-default catalog
+            columns_tpl = {
+                'athena_datasource_arn': 'arn:aws:quicksight:us-east-1:123456789012:datasource/test',
+                'athena_database_name': 'test_db',
+                'athena_catalog_name': catalog_name,
+                'cur_database': 'cur_db',
+                'cur_table_name': 'cur_table',
+                'cur1_database': 'cur_db',
+                'cur1_table_name': 'cur_table',
+                'cur2_database': 'cur2_db',
+                'cur2_table_name': 'cur2_table',
+                'primary_tag_name': 'team',
+                'secondary_tag_name': 'project',
+            }
+
+            # Apply template substitution (same as safe_substitute in cid/common.py)
+            compiled_text = Template(template_text).safe_substitute(columns_tpl)
+            compiled_dataset = json.loads(compiled_text)
+
+            # Check all RelationalTable entries
+            physical_table_map = compiled_dataset.get('PhysicalTableMap', {})
+            for table_key, table_value in physical_table_map.items():
+                if 'RelationalTable' in table_value:
+                    rel_table = table_value['RelationalTable']
+                    catalog_value = rel_table.get('Catalog')
+
+                    assert catalog_value == catalog_name, (
+                        f"In {relative_file}, RelationalTable '{table_key}' has "
+                        f"Catalog='{catalog_value}' but expected '{catalog_name}'. "
+                        f"The Catalog field is {'missing' if catalog_value is None else 'hardcoded'}."
+                    )
+
+
+class TestBugCondition_YAMLDashboardsHardcodedCatalog:
+    """Test that YAML dashboard definitions use template variable for Catalog field.
+
+    This test loads YAML dashboard definitions and checks that RelationalTable
+    Catalog fields use ${athena_catalog_name} rather than hardcoded 'AwsDataCatalog'.
+    """
+
+    @given(catalog_name=catalog_name_strategy)
+    @settings(max_examples=5, deadline=None, suppress_health_check=[HealthCheck.function_scoped_fixture])
+    def test_yaml_dashboards_use_catalog_variable(self, catalog_name):
+        """
+        **Validates: Requirements 1.1, 1.3**
+
+        For any non-default catalog, after template substitution, all
+        RelationalTable.Catalog fields in YAML dashboards MUST equal the selected catalog.
+        """
+        import glob
+        yaml_files = glob.glob(os.path.join(DASHBOARDS_DIR, '**', '*.yaml'), recursive=True)
+        assume(len(yaml_files) > 0)
+
+        # Pick a representative sample - focus.yaml has RelationalTable entries
+        sample_files = [f for f in yaml_files if 'focus' in f.lower()]
+        if not sample_files:
+            sample_files = yaml_files[:3]
+
+        for yaml_file in sample_files:
+            with open(yaml_file, 'r') as f:
+                template_text = f.read()
+
+            # Apply template substitution
+            columns_tpl = {
+                'athena_datasource_arn': 'arn:aws:quicksight:us-east-1:123456789012:datasource/test',
+                'athena_database_name': 'test_db',
+                'athena_catalog_name': catalog_name,
+                'cur_database': 'cur_db',
+                'cur_table_name': 'cur_table',
+                'cur1_database': 'cur_db',
+                'cur1_table_name': 'cur_table',
+                'cur2_database': 'cur2_db',
+                'cur2_table_name': 'cur2_table',
+            }
+
+            compiled_text = Template(template_text).safe_substitute(columns_tpl)
+            resources = yaml.safe_load(compiled_text)
+
+            # Navigate to datasets in the YAML structure
+            datasets = resources.get('datasets', {})
+            for dataset_name, dataset_def in datasets.items():
+                dataset_data = dataset_def.get('data', {})
+                if isinstance(dataset_data, str):
+                    dataset_data = yaml.safe_load(dataset_data) or {}
+
+                physical_table_map = dataset_data.get('PhysicalTableMap', {})
+                for table_key, table_value in physical_table_map.items():
+                    if 'RelationalTable' in table_value:
+                        rel_table = table_value['RelationalTable']
+                        catalog_value = rel_table.get('Catalog')
+                        relative_path = os.path.relpath(yaml_file, PROJECT_ROOT)
+
+                        assert catalog_value == catalog_name, (
+                            f"In {relative_path}, dataset '{dataset_name}', "
+                            f"RelationalTable '{table_key}' has Catalog='{catalog_value}' "
+                            f"but expected '{catalog_name}'. "
+                            f"The YAML dashboard has hardcoded 'AwsDataCatalog'."
+                        )
+
+
+class TestBugCondition_IAMPolicyHardcodedCatalog:
+    """Test that IAM policy resource ARN uses the selected catalog.
+
+    The IAM helper's ensure_data_source_role_exists method should accept a
+    catalog_name parameter instead of hardcoding 'AwsDataCatalog'.
+    """
+
+    @given(catalog_name=catalog_name_strategy)
+    @settings(max_examples=10, suppress_health_check=[HealthCheck.function_scoped_fixture])
+    def test_iam_policy_uses_selected_catalog_in_arn(self, catalog_name):
+        """
+        **Validates: Requirements 1.1**
+
+        The IAM policy resource ARN must reference the selected catalog,
+        not hardcoded 'AwsDataCatalog'.
+        """
+        # Read the IAM helper source to verify the hardcoded pattern is gone
+        iam_file = os.path.join(PROJECT_ROOT, 'cid', 'helpers', 'iam.py')
+        with open(iam_file, 'r') as f:
+            iam_source = f.read()
+
+        # The fix should have removed the hardcoded 'datacatalog/AwsDataCatalog'
+        assert 'datacatalog/AwsDataCatalog' not in iam_source, (
+            f"cid/helpers/iam.py contains hardcoded 'datacatalog/AwsDataCatalog' "
+            f"in the IAM policy resource ARN. When catalog '{catalog_name}' is selected, "
+            f"the ARN should reference 'datacatalog/{catalog_name}' instead."
+        )
+
+
+class TestBugCondition_ExportDoesNotTemplatizeCatalog:
+    """Test that export.py templatizes the Catalog field in RelationalTable.
+
+    This test reads the actual cid/export.py source to verify the fix is in place.
+    """
+
+    @given(catalog_name=catalog_name_strategy)
+    @settings(max_examples=10, suppress_health_check=[HealthCheck.function_scoped_fixture])
+    def test_export_templatizes_catalog_field(self, catalog_name):
+        """
+        **Validates: Requirements 1.1**
+
+        The export logic must templatize the Catalog field to ${athena_catalog_name}
+        when processing RelationalTable entries.
+        """
+        # Read the actual export.py source code
+        export_file = os.path.join(PROJECT_ROOT, 'cid', 'export.py')
+        with open(export_file, 'r') as f:
+            export_source = f.read()
+
+        # Verify that the Catalog field is templatized in the RelationalTable block
+        # The fix adds: value['RelationalTable']['Catalog'] = '${athena_catalog_name}'
+        assert "${athena_catalog_name}" in export_source, (
+            "cid/export.py does not contain '${athena_catalog_name}'. "
+            "The export logic must templatize the Catalog field to '${athena_catalog_name}' "
+            "when processing RelationalTable entries."
+        )
+
+        # Verify the specific pattern assigning to Catalog
+        pattern = r"""value\['RelationalTable'\]\['Catalog'\]\s*=\s*['"]\$\{athena_catalog_name\}['"]"""
+        assert re.search(pattern, export_source), (
+            "cid/export.py does not assign '${athena_catalog_name}' to "
+            "value['RelationalTable']['Catalog']. The export logic must templatize "
+            "the Catalog field when processing RelationalTable entries."
+        )

--- a/cid/test/python/test_preservation_catalog_selection.py
+++ b/cid/test/python/test_preservation_catalog_selection.py
@@ -1,0 +1,643 @@
+"""
+Preservation Property Tests: Default Catalog Behavior Unchanged
+
+**Validates: Requirements 3.1, 3.2, 3.3, 3.4, 3.5**
+
+Property 2: Preservation - Default Catalog Behavior Unchanged
+
+These tests MUST PASS on UNFIXED code. They confirm baseline behavior that
+the fix must not break. They verify that:
+1. With single catalog (AwsDataCatalog), datasets use AwsDataCatalog in Catalog field
+2. With default catalog explicitly selected, behavior is identical
+3. Other template variables substitute correctly regardless of catalog
+4. YAML non-dataset content (dashboards, layout) is unchanged
+5. Export logic templatizes DataSourceArn and Schema correctly
+"""
+import json
+import os
+import glob
+from string import Template
+
+import yaml
+import pytest
+from hypothesis import given, settings, assume, HealthCheck, Phase
+from hypothesis import strategies as st
+
+
+# Project root for locating dataset templates and YAML dashboards
+PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', '..'))
+DATASETS_DIR = os.path.join(PROJECT_ROOT, 'cid', 'builtin', 'core', 'data', 'datasets')
+DASHBOARDS_DIR = os.path.join(PROJECT_ROOT, 'dashboards')
+
+
+# Strategy: Generate valid template variable values for non-catalog variables
+datasource_arn_strategy = st.from_regex(
+    r'arn:aws:quicksight:us-east-1:[0-9]{12}:datasource/[a-z0-9\-]{10,36}',
+    fullmatch=True,
+)
+database_name_strategy = st.text(
+    alphabet=st.characters(whitelist_categories=('Ll',), whitelist_characters='_'),
+    min_size=3,
+    max_size=20,
+).filter(lambda x: x.strip() == x and len(x) >= 3 and x not in (
+    'true', 'false', 'yes', 'no', 'on', 'off', 'null', 'none',
+))
+
+table_name_strategy = st.text(
+    alphabet=st.characters(whitelist_categories=('Ll',), whitelist_characters='_'),
+    min_size=3,
+    max_size=20,
+).filter(lambda x: x.strip() == x and len(x) >= 3 and x not in (
+    'true', 'false', 'yes', 'no', 'on', 'off', 'null', 'none',
+))
+
+
+class TestPreservation_DefaultCatalogInJSONTemplates:
+    """Test that JSON dataset templates use AwsDataCatalog when default catalog is active.
+
+    **Validates: Requirements 3.1, 3.2**
+
+    In default-catalog environments (single catalog or AwsDataCatalog selected),
+    the RelationalTable.Catalog field remains "AwsDataCatalog" after template
+    substitution. The templates now use ${athena_catalog_name} which resolves to
+    "AwsDataCatalog" when the default catalog is selected. This is the correct
+    behavior that preserves backward compatibility.
+    """
+
+    @given(
+        datasource_arn=datasource_arn_strategy,
+        database_name=database_name_strategy,
+    )
+    @settings(max_examples=10, deadline=None, suppress_health_check=[HealthCheck.function_scoped_fixture])
+    def test_json_templates_preserve_default_catalog(self, datasource_arn, database_name):
+        """
+        **Validates: Requirements 3.1, 3.2**
+
+        For default catalog scenarios, JSON dataset templates MUST produce
+        Catalog="AwsDataCatalog" in all RelationalTable entries after substitution.
+        The templates use ${athena_catalog_name} which resolves to "AwsDataCatalog"
+        when the default catalog is selected.
+        """
+        json_files = glob.glob(os.path.join(DATASETS_DIR, '**', '*.json'), recursive=True)
+        assume(len(json_files) > 0)
+
+        for json_file in json_files:
+            with open(json_file, 'r') as f:
+                template_text = f.read()
+
+            # Build columns_tpl with athena_catalog_name set to the default catalog
+            # This simulates the fixed code in a default-catalog environment
+            columns_tpl = {
+                'athena_datasource_arn': datasource_arn,
+                'athena_database_name': database_name,
+                'athena_catalog_name': 'AwsDataCatalog',
+                'cur_database': 'cur_db',
+                'cur_table_name': 'cur_table',
+                'cur1_database': 'cur_db',
+                'cur1_table_name': 'cur_table',
+                'cur2_database': 'cur2_db',
+                'cur2_table_name': 'cur2_table',
+                'primary_tag_name': 'team',
+                'secondary_tag_name': 'project',
+            }
+
+            compiled_text = Template(template_text).safe_substitute(columns_tpl)
+            compiled_dataset = json.loads(compiled_text)
+
+            # Verify all RelationalTable entries that have a Catalog field
+            # resolve to "AwsDataCatalog" after template substitution
+            physical_table_map = compiled_dataset.get('PhysicalTableMap', {})
+            for table_key, table_value in physical_table_map.items():
+                if 'RelationalTable' in table_value:
+                    rel_table = table_value['RelationalTable']
+                    catalog_value = rel_table.get('Catalog')
+                    relative_path = os.path.relpath(json_file, PROJECT_ROOT)
+
+                    if catalog_value is not None:
+                        # When Catalog is present, it should resolve to AwsDataCatalog
+                        assert catalog_value == 'AwsDataCatalog', (
+                            f"In {relative_path}, RelationalTable '{table_key}' "
+                            f"Catalog='{catalog_value}', expected 'AwsDataCatalog' "
+                            f"in default catalog scenario."
+                        )
+
+
+class TestPreservation_TemplateVariableSubstitution:
+    """Test that standard template variables substitute correctly.
+
+    **Validates: Requirements 3.3**
+
+    Regardless of catalog selection, the other template variables
+    (athena_datasource_arn, athena_database_name, cur_database, cur_table_name)
+    must substitute correctly in both JSON and YAML templates.
+    """
+
+    @given(
+        datasource_arn=datasource_arn_strategy,
+        database_name=database_name_strategy,
+        cur_database=database_name_strategy,
+        cur_table_name=table_name_strategy,
+    )
+    @settings(max_examples=10, deadline=None, suppress_health_check=[HealthCheck.function_scoped_fixture])
+    def test_json_template_variables_substitute_correctly(
+        self, datasource_arn, database_name, cur_database, cur_table_name
+    ):
+        """
+        **Validates: Requirements 3.3**
+
+        For all JSON dataset templates, template variables
+        ${athena_datasource_arn} and ${athena_database_name} MUST be
+        substituted with the provided values. No unresolved template
+        variables should remain in DataSourceArn or Schema fields.
+        """
+        json_files = glob.glob(os.path.join(DATASETS_DIR, '**', '*.json'), recursive=True)
+        assume(len(json_files) > 0)
+
+        for json_file in json_files:
+            with open(json_file, 'r') as f:
+                template_text = f.read()
+
+            columns_tpl = {
+                'athena_datasource_arn': datasource_arn,
+                'athena_database_name': database_name,
+                'cur_database': cur_database,
+                'cur_table_name': cur_table_name,
+                'cur1_database': cur_database,
+                'cur1_table_name': cur_table_name,
+                'cur2_database': cur_database,
+                'cur2_table_name': cur_table_name,
+                'primary_tag_name': 'team',
+                'secondary_tag_name': 'project',
+            }
+
+            compiled_text = Template(template_text).safe_substitute(columns_tpl)
+            compiled_dataset = json.loads(compiled_text)
+
+            physical_table_map = compiled_dataset.get('PhysicalTableMap', {})
+            for table_key, table_value in physical_table_map.items():
+                if 'RelationalTable' in table_value:
+                    rel_table = table_value['RelationalTable']
+                    relative_path = os.path.relpath(json_file, PROJECT_ROOT)
+
+                    # DataSourceArn must be fully substituted
+                    assert rel_table.get('DataSourceArn') == datasource_arn, (
+                        f"In {relative_path}, RelationalTable '{table_key}' "
+                        f"DataSourceArn='{rel_table.get('DataSourceArn')}', "
+                        f"expected '{datasource_arn}'."
+                    )
+
+                    # Schema must be fully resolved (no unresolved variables)
+                    # Some templates use ${athena_database_name}, others use
+                    # ${cur_database} or ${cur1_database}, all should resolve
+                    schema_value = rel_table.get('Schema', '')
+                    assert '${' not in schema_value, (
+                        f"In {relative_path}, RelationalTable '{table_key}' "
+                        f"Schema='{schema_value}' has unresolved template variable."
+                    )
+
+    @given(
+        datasource_arn=datasource_arn_strategy,
+        database_name=database_name_strategy,
+    )
+    @settings(max_examples=5, deadline=None, suppress_health_check=[HealthCheck.function_scoped_fixture])
+    def test_yaml_template_variables_substitute_correctly(
+        self, datasource_arn, database_name
+    ):
+        """
+        **Validates: Requirements 3.3**
+
+        For YAML dashboard definitions, template variables
+        ${athena_datasource_arn} and ${athena_database_name} MUST be
+        substituted with the provided values in RelationalTable entries.
+        """
+        # Use a small representative sample of YAML files
+        yaml_files = glob.glob(os.path.join(DASHBOARDS_DIR, '**', '*.yaml'), recursive=True)
+        assume(len(yaml_files) > 0)
+
+        # Pick small files for efficiency
+        sample_files = [f for f in yaml_files if 'rls' in f.lower() or 'cloudfront_realtime' in f.lower()]
+        if not sample_files:
+            sample_files = yaml_files[:2]
+
+        for yaml_file in sample_files:
+            with open(yaml_file, 'r') as f:
+                template_text = f.read()
+
+            columns_tpl = {
+                'athena_datasource_arn': datasource_arn,
+                'athena_database_name': database_name,
+                'athena_catalog_name': 'AwsDataCatalog',  # default catalog
+                'cur_database': 'cur_db',
+                'cur_table_name': 'cur_table',
+                'cur1_database': 'cur_db',
+                'cur1_table_name': 'cur_table',
+                'cur2_database': 'cur2_db',
+                'cur2_table_name': 'cur2_table',
+            }
+
+            compiled_text = Template(template_text).safe_substitute(columns_tpl)
+            resources = yaml.safe_load(compiled_text)
+
+            datasets = resources.get('datasets', {})
+            for dataset_name, dataset_def in datasets.items():
+                dataset_data = dataset_def.get('data', {})
+                if isinstance(dataset_data, str):
+                    continue  # Skip string refs
+
+                physical_table_map = dataset_data.get('PhysicalTableMap', {})
+                for table_key, table_value in physical_table_map.items():
+                    if 'RelationalTable' in table_value:
+                        rel_table = table_value['RelationalTable']
+                        relative_path = os.path.relpath(yaml_file, PROJECT_ROOT)
+
+                        # DataSourceArn must be substituted
+                        assert rel_table.get('DataSourceArn') == datasource_arn, (
+                            f"In {relative_path}, dataset '{dataset_name}', "
+                            f"RelationalTable '{table_key}' "
+                            f"DataSourceArn='{rel_table.get('DataSourceArn')}', "
+                            f"expected '{datasource_arn}'."
+                        )
+
+                        # Schema must be substituted (no unresolved variables)
+                        schema_value = rel_table.get('Schema')
+                        if isinstance(schema_value, str):
+                            assert '${' not in schema_value, (
+                                f"In {relative_path}, dataset '{dataset_name}', "
+                                f"RelationalTable '{table_key}' "
+                                f"Schema='{schema_value}' has unresolved template variable."
+                            )
+
+
+class TestPreservation_YAMLDashboardDefaultCatalog:
+    """Test that YAML dashboards resolve Catalog to AwsDataCatalog for default catalog.
+
+    **Validates: Requirements 3.1, 3.2**
+
+    When the default catalog (AwsDataCatalog) is used, all YAML dashboard
+    RelationalTable entries must resolve Catalog to AwsDataCatalog after
+    template substitution. The templates now use ${athena_catalog_name} which
+    resolves to "AwsDataCatalog" when the default catalog is selected.
+    """
+
+    @given(
+        datasource_arn=datasource_arn_strategy,
+        database_name=database_name_strategy,
+    )
+    @settings(max_examples=5, deadline=None, suppress_health_check=[HealthCheck.function_scoped_fixture])
+    def test_yaml_dashboards_preserve_default_catalog(self, datasource_arn, database_name):
+        """
+        **Validates: Requirements 3.1, 3.2**
+
+        For default catalog scenarios, all YAML dashboard RelationalTable entries
+        with a Catalog field MUST have Catalog="AwsDataCatalog" after substitution.
+        The templates use ${athena_catalog_name} which resolves to "AwsDataCatalog"
+        when the default catalog is selected.
+        """
+        yaml_files = glob.glob(os.path.join(DASHBOARDS_DIR, '**', '*.yaml'), recursive=True)
+        assume(len(yaml_files) > 0)
+
+        # Use a representative sample to keep tests fast
+        sample_files = [
+            f for f in yaml_files
+            if any(name in f.lower() for name in ['tao', 'rls', 'health-events'])
+        ]
+        if not sample_files:
+            sample_files = yaml_files[:3]
+
+        for yaml_file in sample_files:
+            with open(yaml_file, 'r') as f:
+                template_text = f.read()
+
+            # Simulate default catalog scenario with athena_catalog_name set
+            columns_tpl = {
+                'athena_datasource_arn': datasource_arn,
+                'athena_database_name': database_name,
+                'athena_catalog_name': 'AwsDataCatalog',
+                'cur_database': 'cur_db',
+                'cur_table_name': 'cur_table',
+                'cur1_database': 'cur_db',
+                'cur1_table_name': 'cur_table',
+                'cur2_database': 'cur2_db',
+                'cur2_table_name': 'cur2_table',
+            }
+
+            compiled_text = Template(template_text).safe_substitute(columns_tpl)
+            resources = yaml.safe_load(compiled_text)
+
+            datasets = resources.get('datasets', {})
+            for dataset_name, dataset_def in datasets.items():
+                dataset_data = dataset_def.get('data', {})
+                if isinstance(dataset_data, str):
+                    continue
+
+                physical_table_map = dataset_data.get('PhysicalTableMap', {})
+                for table_key, table_value in physical_table_map.items():
+                    if 'RelationalTable' in table_value:
+                        rel_table = table_value['RelationalTable']
+                        catalog_value = rel_table.get('Catalog')
+                        relative_path = os.path.relpath(yaml_file, PROJECT_ROOT)
+
+                        if catalog_value is not None:
+                            assert catalog_value == 'AwsDataCatalog', (
+                                f"In {relative_path}, dataset '{dataset_name}', "
+                                f"RelationalTable '{table_key}' has "
+                                f"Catalog='{catalog_value}', expected 'AwsDataCatalog' "
+                                f"in default catalog scenario."
+                            )
+
+
+class TestPreservation_YAMLNonDatasetContentUnchanged:
+    """Test that YAML non-dataset content (dashboards, layout) is unaffected.
+
+    **Validates: Requirements 3.5**
+
+    Template substitution must not alter non-dataset content in YAML files
+    such as dashboard configuration, visualization definitions, etc.
+    """
+
+    @given(
+        datasource_arn=datasource_arn_strategy,
+        database_name=database_name_strategy,
+    )
+    @settings(max_examples=5, deadline=None, suppress_health_check=[HealthCheck.function_scoped_fixture])
+    def test_yaml_dashboard_config_preserved(self, datasource_arn, database_name):
+        """
+        **Validates: Requirements 3.5**
+
+        Template substitution MUST NOT alter the 'dashboards' section structure
+        (dashboard names, IDs, versions, categories, themes) in YAML files.
+        """
+        yaml_files = glob.glob(os.path.join(DASHBOARDS_DIR, '**', '*.yaml'), recursive=True)
+        assume(len(yaml_files) > 0)
+
+        # Use focus.yaml as it has a well-defined dashboards section
+        sample_files = [f for f in yaml_files if 'focus' in os.path.basename(f).lower()]
+        if not sample_files:
+            sample_files = yaml_files[:1]
+
+        for yaml_file in sample_files:
+            with open(yaml_file, 'r') as f:
+                template_text = f.read()
+
+            # Parse BEFORE substitution - to get the raw dashboard config
+            # (The dashboards section doesn't use template variables)
+            raw_resources = yaml.safe_load(template_text)
+            raw_dashboards = raw_resources.get('dashboards', {})
+
+            # Parse AFTER substitution
+            columns_tpl = {
+                'athena_datasource_arn': datasource_arn,
+                'athena_database_name': database_name,
+                'cur_database': 'cur_db',
+                'cur_table_name': 'cur_table',
+                'cur1_database': 'cur_db',
+                'cur1_table_name': 'cur_table',
+                'cur2_database': 'cur2_db',
+                'cur2_table_name': 'cur2_table',
+            }
+
+            compiled_text = Template(template_text).safe_substitute(columns_tpl)
+            compiled_resources = yaml.safe_load(compiled_text)
+            compiled_dashboards = compiled_resources.get('dashboards', {})
+
+            # Dashboard structure must be identical (names, IDs, versions)
+            assert set(raw_dashboards.keys()) == set(compiled_dashboards.keys()), (
+                f"Dashboard keys changed after substitution in {yaml_file}"
+            )
+
+            for dash_name in raw_dashboards:
+                raw_dash = raw_dashboards[dash_name]
+                compiled_dash = compiled_dashboards[dash_name]
+
+                # name, dashboardId, version, category, theme must be unchanged
+                for key in ['name', 'dashboardId', 'version', 'category', 'theme']:
+                    if key in raw_dash:
+                        assert raw_dash[key] == compiled_dash.get(key), (
+                            f"Dashboard '{dash_name}' key '{key}' changed: "
+                            f"'{raw_dash[key]}' -> '{compiled_dash.get(key)}'"
+                        )
+
+
+class TestPreservation_ExportTemplatizesExistingFields:
+    """Test that the export logic correctly templatizes DataSourceArn and Schema.
+
+    **Validates: Requirements 3.5**
+
+    The export logic in cid/export.py currently templatizes:
+    - DataSourceArn -> ${athena_datasource_arn}
+    - Schema -> ${athena_database_name} (for the default database)
+
+    This behavior must be preserved regardless of any Catalog changes.
+    """
+
+    @given(
+        original_arn=datasource_arn_strategy,
+        database_name=database_name_strategy,
+    )
+    @settings(max_examples=10, deadline=None, suppress_health_check=[HealthCheck.function_scoped_fixture])
+    def test_export_templatizes_datasource_arn_and_schema(self, original_arn, database_name):
+        """
+        **Validates: Requirements 3.5**
+
+        The export logic MUST templatize DataSourceArn to ${athena_datasource_arn}
+        and Schema to ${athena_database_name} for RelationalTable entries.
+        """
+        # Simulate the export logic from cid/export.py (~line 168-179)
+        dataset_data = {
+            'PhysicalTableMap': {
+                'table-1': {
+                    'RelationalTable': {
+                        'DataSourceArn': original_arn,
+                        'Schema': database_name,
+                        'Catalog': 'AwsDataCatalog',
+                        'Name': 'some_view',
+                    }
+                }
+            }
+        }
+
+        # Replicate the exact export logic (from cid/export.py)
+        all_views_and_databases = []
+        for key, value in dataset_data['PhysicalTableMap'].items():
+            if 'RelationalTable' in value \
+                and 'DataSourceArn' in value['RelationalTable'] \
+                and 'Schema' in value['RelationalTable']:
+                value['RelationalTable']['DataSourceArn'] = '${athena_datasource_arn}'
+                database_name_val = value['RelationalTable']['Schema']
+                discovered_databases = list(set([d for _, d in all_views_and_databases]))
+                if not discovered_databases or discovered_databases[0] == database_name_val:
+                    value['RelationalTable']['Schema'] = '${athena_database_name}'
+
+        # Verify DataSourceArn was templatized
+        for key, value in dataset_data['PhysicalTableMap'].items():
+            if 'RelationalTable' in value:
+                assert value['RelationalTable']['DataSourceArn'] == '${athena_datasource_arn}', (
+                    f"Export should templatize DataSourceArn to '${{athena_datasource_arn}}', "
+                    f"got '{value['RelationalTable']['DataSourceArn']}'"
+                )
+                assert value['RelationalTable']['Schema'] == '${athena_database_name}', (
+                    f"Export should templatize Schema to '${{athena_database_name}}', "
+                    f"got '{value['RelationalTable']['Schema']}'"
+                )
+
+    @given(
+        original_arn=datasource_arn_strategy,
+        database_name=database_name_strategy,
+    )
+    @settings(max_examples=10, deadline=None, suppress_health_check=[HealthCheck.function_scoped_fixture])
+    def test_export_preserves_catalog_as_literal(self, original_arn, database_name):
+        """
+        **Validates: Requirements 3.5**
+
+        On UNFIXED code, the export logic leaves the Catalog field as-is
+        (the literal value from the live dataset). This test documents
+        the current behavior that Catalog is NOT templatized.
+        """
+        # Simulate the export logic from cid/export.py (~line 168-179)
+        dataset_data = {
+            'PhysicalTableMap': {
+                'table-1': {
+                    'RelationalTable': {
+                        'DataSourceArn': original_arn,
+                        'Schema': database_name,
+                        'Catalog': 'AwsDataCatalog',
+                        'Name': 'some_view',
+                    }
+                }
+            }
+        }
+
+        # Replicate the exact export logic (from cid/export.py)
+        all_views_and_databases = []
+        for key, value in dataset_data['PhysicalTableMap'].items():
+            if 'RelationalTable' in value \
+                and 'DataSourceArn' in value['RelationalTable'] \
+                and 'Schema' in value['RelationalTable']:
+                value['RelationalTable']['DataSourceArn'] = '${athena_datasource_arn}'
+                database_name_val = value['RelationalTable']['Schema']
+                discovered_databases = list(set([d for _, d in all_views_and_databases]))
+                if not discovered_databases or discovered_databases[0] == database_name_val:
+                    value['RelationalTable']['Schema'] = '${athena_database_name}'
+                # NOTE: The export logic does NOT touch Catalog - this is the bug
+                # but for preservation, we document that Catalog remains literal
+
+        # On unfixed code, Catalog remains as-is (AwsDataCatalog literal)
+        for key, value in dataset_data['PhysicalTableMap'].items():
+            if 'RelationalTable' in value:
+                catalog_value = value['RelationalTable'].get('Catalog')
+                assert catalog_value == 'AwsDataCatalog', (
+                    f"On unfixed code, export should leave Catalog as literal "
+                    f"'AwsDataCatalog', got '{catalog_value}'"
+                )
+
+
+class TestPreservation_IAMPolicyDefaultCatalog:
+    """Test that IAM policy uses AwsDataCatalog in the resource ARN by default.
+
+    **Validates: Requirements 3.5**
+
+    The IAM helper's ensure_data_source_role_exists now accepts a catalog_name
+    parameter with a default of 'AwsDataCatalog'. For default-catalog
+    environments, the function signature default ensures backward compatibility.
+    """
+
+    def test_iam_policy_supports_default_catalog(self):
+        """
+        **Validates: Requirements 3.5**
+
+        The IAM policy function MUST have a catalog_name parameter that defaults
+        to 'AwsDataCatalog', ensuring backward compatibility for default-catalog
+        scenarios. The function must support dynamic catalog names via parameter.
+        """
+        iam_file = os.path.join(PROJECT_ROOT, 'cid', 'helpers', 'iam.py')
+        with open(iam_file, 'r') as f:
+            iam_source = f.read()
+
+        # The function should accept a catalog_name parameter
+        assert 'catalog_name' in iam_source, (
+            "cid/helpers/iam.py should contain a 'catalog_name' parameter "
+            "for dynamic catalog support."
+        )
+
+        # The default value should be 'AwsDataCatalog' for backward compatibility
+        assert "'AwsDataCatalog'" in iam_source, (
+            "cid/helpers/iam.py should contain 'AwsDataCatalog' as the default "
+            "value for the catalog_name parameter."
+        )
+
+        # The function should use datacatalog/ pattern in the ARN
+        assert 'datacatalog/' in iam_source, (
+            "cid/helpers/iam.py should contain 'datacatalog/' for "
+            "constructing the IAM resource ARN."
+        )
+
+
+class TestPreservation_ColumnsTPLCurrentBehavior:
+    """Test that columns_tpl contains the expected current set of keys.
+
+    **Validates: Requirements 3.3, 3.4**
+
+    The current columns_tpl dictionary in create_or_update_dataset
+    includes specific keys. This test verifies those keys are present
+    and functional for template substitution.
+    """
+
+    @given(
+        datasource_arn=datasource_arn_strategy,
+        database_name=database_name_strategy,
+        cur_database=database_name_strategy,
+        cur_table_name=table_name_strategy,
+    )
+    @settings(max_examples=10, deadline=None, suppress_health_check=[HealthCheck.function_scoped_fixture])
+    def test_columns_tpl_current_keys_work(
+        self, datasource_arn, database_name, cur_database, cur_table_name
+    ):
+        """
+        **Validates: Requirements 3.3, 3.4**
+
+        The columns_tpl dictionary MUST include athena_datasource_arn,
+        athena_database_name, cur_database, cur_table_name and they
+        MUST produce valid JSON when substituted into templates.
+        """
+        # Replicate current columns_tpl structure (without athena_catalog_name)
+        columns_tpl = {
+            'athena_datasource_arn': datasource_arn,
+            'athena_database_name': database_name,
+            'cur_database': cur_database,
+            'cur_table_name': cur_table_name,
+            'cur1_database': cur_database,
+            'cur1_table_name': cur_table_name,
+            'cur2_database': cur_database,
+            'cur2_table_name': cur_table_name,
+            'primary_tag_name': 'team',
+            'secondary_tag_name': 'project',
+        }
+
+        # Verify these produce valid JSON for at least one template
+        json_files = glob.glob(os.path.join(DATASETS_DIR, '**', '*.json'), recursive=True)
+        assume(len(json_files) > 0)
+
+        # Test with the co/dataset.json (known to have all relevant fields)
+        co_dataset = os.path.join(DATASETS_DIR, 'co', 'dataset.json')
+        if os.path.exists(co_dataset):
+            with open(co_dataset, 'r') as f:
+                template_text = f.read()
+
+            compiled_text = Template(template_text).safe_substitute(columns_tpl)
+
+            # Must produce valid JSON
+            compiled_dataset = json.loads(compiled_text)
+            assert 'PhysicalTableMap' in compiled_dataset
+            assert 'DataSetId' in compiled_dataset
+
+            # DataSourceArn and Schema should be fully resolved
+            for table_key, table_value in compiled_dataset['PhysicalTableMap'].items():
+                if 'RelationalTable' in table_value:
+                    rel_table = table_value['RelationalTable']
+                    # No unresolved template variables in these fields
+                    assert '${' not in rel_table['DataSourceArn'], (
+                        f"Unresolved variable in DataSourceArn: {rel_table['DataSourceArn']}"
+                    )
+                    assert '${' not in rel_table['Schema'], (
+                        f"Unresolved variable in Schema: {rel_table['Schema']}"
+                    )

--- a/dashboards/amazon-connect/amazon-connect.yaml
+++ b/dashboards/amazon-connect/amazon-connect.yaml
@@ -21087,7 +21087,7 @@ datasets:
         262bcde8-fd8b-46b0-906e-9ea47394ffa8:
           RelationalTable:
             DataSourceArn: ${athena_datasource_arn}
-            Catalog: AwsDataCatalog
+            Catalog: ${athena_catalog_name}
             Schema: ${athena_database_name}
             Name: resource_connect_contact_summary_view
             InputColumns:
@@ -21130,7 +21130,7 @@ datasets:
         6de73818-2adf-47d0-9638-00703f1d3b04:
           RelationalTable:
             DataSourceArn: ${athena_datasource_arn}
-            Catalog: AwsDataCatalog
+            Catalog: ${athena_catalog_name}
             Schema: ${athena_database_name}
             Name: resource_connect_view
             InputColumns:
@@ -21199,7 +21199,7 @@ datasets:
         d7487789-c916-4f54-8058-526658d9c7d7:
           RelationalTable:
             DataSourceArn: ${athena_datasource_arn}
-            Catalog: AwsDataCatalog
+            Catalog: ${athena_catalog_name}
             Schema: ${athena_database_name}
             Name: account_map
             InputColumns:

--- a/dashboards/aws-budgets/aws-budgets.yaml
+++ b/dashboards/aws-budgets/aws-budgets.yaml
@@ -1973,7 +1973,7 @@ datasets:
         837bbb14-78d7-44f6-8733-35c9d535665c:
           RelationalTable:
             DataSourceArn: ${athena_datasource_arn}
-            Catalog: AwsDataCatalog
+            Catalog: ${athena_catalog_name}
             Schema: ${athena_database_name}
             Name: account_map
             InputColumns:
@@ -1984,7 +1984,7 @@ datasets:
         92380c13-4243-40f6-849c-2fefa127e241:
           RelationalTable:
             DataSourceArn: ${athena_datasource_arn}
-            Catalog: AwsDataCatalog
+            Catalog: ${athena_catalog_name}
             Schema: ${athena_database_name}
             Name: budgets_view
             InputColumns:

--- a/dashboards/aws-feeds/aws-feeds.yaml
+++ b/dashboards/aws-feeds/aws-feeds.yaml
@@ -2898,7 +2898,7 @@ datasets:
         6593bf38-e15a-41d7-b85c-9d5d2ea4027f:
           RelationalTable:
             DataSourceArn: ${athena_datasource_arn}
-            Catalog: AwsDataCatalog
+            Catalog: ${athena_catalog_name}
             Schema: ${athena_database_name}
             Name: aws_feeds
             InputColumns:
@@ -2944,7 +2944,7 @@ datasets:
         ce6e7be8-3a44-4325-b55d-26ab590920d1:
           RelationalTable:
             DataSourceArn: ${athena_datasource_arn}
-            Catalog: AwsDataCatalog
+            Catalog: ${athena_catalog_name}
             Schema: ${data_collection_database_name}
             Name: aws_feeds_blog_post
             InputColumns:
@@ -3010,7 +3010,7 @@ datasets:
         ff99854e-942d-4312-9700-423f15e4d21c:
           RelationalTable:
             DataSourceArn: ${athena_datasource_arn}
-            Catalog: AwsDataCatalog
+            Catalog: ${athena_catalog_name}
             Schema: ${data_collection_database_name}
             Name: aws_feeds_security_bulletin
             InputColumns:
@@ -3070,7 +3070,7 @@ datasets:
         720118c4-3819-4fb9-bdbe-1666f7089c5c:
           RelationalTable:
             DataSourceArn: ${athena_datasource_arn}
-            Catalog: AwsDataCatalog
+            Catalog: ${athena_catalog_name}
             Schema: ${data_collection_database_name}
             Name: aws_feeds_whats_new
             InputColumns:
@@ -3136,7 +3136,7 @@ datasets:
         5b308e9b-d8cf-4223-a79c-8cf1d09f371f:
           RelationalTable:
             DataSourceArn: ${athena_datasource_arn}
-            Catalog: AwsDataCatalog
+            Catalog: ${athena_catalog_name}
             Schema: ${data_collection_database_name}
             Name: aws_feeds_youtube
             InputColumns:

--- a/dashboards/aws-marketplace/aws-marketplace-spg.yaml
+++ b/dashboards/aws-marketplace/aws-marketplace-spg.yaml
@@ -20,7 +20,7 @@ datasets:
         208c509d-f59c-44d2-96d2-3e146f100734:
           RelationalTable:
             DataSourceArn: ${athena_datasource_arn}
-            Catalog: AwsDataCatalog
+            Catalog: ${athena_catalog_name}
             Schema: ${athena_database_name}
             Name: account_map
             InputColumns:
@@ -31,7 +31,7 @@ datasets:
         a2826a94-1e6d-4bd1-8cac-5e35c9124af0:
           RelationalTable:
             DataSourceArn: ${athena_datasource_arn}
-            Catalog: AwsDataCatalog
+            Catalog: ${athena_catalog_name}
             Schema: ${athena_database_name}
             Name: marketplace_view
             InputColumns:
@@ -145,7 +145,7 @@ datasets:
         1ecbb2ac-1ceb-4653-ab08-dc11fdfeb1b1:
           RelationalTable:
             DataSourceArn: ${athena_datasource_arn}
-            Catalog: AwsDataCatalog
+            Catalog: ${athena_catalog_name}
             Schema: ${athena_database_name}
             Name: account_map
             InputColumns:
@@ -156,7 +156,7 @@ datasets:
         623cef5c-7541-4cb2-9474-53cb0e222d67:
           RelationalTable:
             DataSourceArn: ${athena_datasource_arn}
-            Catalog: AwsDataCatalog
+            Catalog: ${athena_catalog_name}
             Schema: ${athena_database_name}
             Name: marketplace_licenses_grants_view
             InputColumns:
@@ -205,7 +205,7 @@ datasets:
         d16218ab-6c10-4003-8a81-b34b069e67b3:
           RelationalTable:
             DataSourceArn: ${athena_datasource_arn}
-            Catalog: AwsDataCatalog
+            Catalog: ${athena_catalog_name}
             Schema: ${athena_database_name}
             Name: account_map
             InputColumns:
@@ -296,7 +296,7 @@ datasets:
         46ae6d3a-5d24-4e0b-a0dc-efa4ff57d116:
           RelationalTable:
             DataSourceArn: ${athena_datasource_arn}
-            Catalog: AwsDataCatalog
+            Catalog: ${athena_catalog_name}
             Schema: ${athena_database_name}
             Name: agreements
             InputColumns:
@@ -361,7 +361,7 @@ datasets:
         cca4b668-6e89-4734-b32d-44f853c796b9:
           RelationalTable:
             DataSourceArn: ${athena_datasource_arn}
-            Catalog: AwsDataCatalog
+            Catalog: ${athena_catalog_name}
             Schema: ${athena_database_name}
             Name: terms
             InputColumns:

--- a/dashboards/cloudfront-dashboard-templates/cloudfront_realtime_logs_dashboard.yaml
+++ b/dashboards/cloudfront-dashboard-templates/cloudfront_realtime_logs_dashboard.yaml
@@ -17,7 +17,7 @@ datasets:
         24ed250c-dca7-41e6-9375-eb10bb21c036:
           RelationalTable:
             DataSourceArn: ${athena_datasource_arn}
-            Catalog: AwsDataCatalog
+            Catalog: ${athena_catalog_name}
             Schema: ${athena_database_name}
             Name: cloudfront_realtime_logs
             InputColumns:

--- a/dashboards/cloudfront-dashboard-templates/cloudfront_standard_logs_dashboard.yaml
+++ b/dashboards/cloudfront-dashboard-templates/cloudfront_standard_logs_dashboard.yaml
@@ -17,7 +17,7 @@ datasets:
         cb9b13e4-29ff-406d-8de2-796770b3ac79:
           RelationalTable:
             DataSourceArn: ${athena_datasource_arn}
-            Catalog: AwsDataCatalog
+            Catalog: ${athena_catalog_name}
             Schema: ${athena_database_name}
             Name: cloudfront_standard_logs
             InputColumns:

--- a/dashboards/cora/cora.yaml
+++ b/dashboards/cora/cora.yaml
@@ -18,7 +18,7 @@ datasets:
         3803f554-6ebc-4256-96e7-ec0661db164b:
           RelationalTable:
             DataSourceArn: ${athena_datasource_arn}
-            Catalog: AwsDataCatalog
+            Catalog: ${athena_catalog_name}
             Schema: ${account_map_database_name}
             Name: account_map
             InputColumns:
@@ -29,7 +29,7 @@ datasets:
         50abacdb-9086-41a9-a217-a2adf45e448c:
           RelationalTable:
             DataSourceArn: ${athena_datasource_arn}
-            Catalog: AwsDataCatalog
+            Catalog: ${athena_catalog_name}
             Schema: ${athena_database_name}
             Name: cora_view
             InputColumns:

--- a/dashboards/cost-anomalies/cost-anomalies.yaml
+++ b/dashboards/cost-anomalies/cost-anomalies.yaml
@@ -1575,7 +1575,7 @@ datasets:
         3cec5d27-cc1d-4503-9b2e-c2bf0ce7b389:
           RelationalTable:
             DataSourceArn: ${athena_datasource_arn}
-            Catalog: AwsDataCatalog
+            Catalog: ${athena_catalog_name}
             Schema: ${athena_database_name}
             Name: cost_anomalies
             InputColumns:

--- a/dashboards/data-collection-monitor/data-collection-monitor.yaml
+++ b/dashboards/data-collection-monitor/data-collection-monitor.yaml
@@ -1822,7 +1822,7 @@ datasets:
         dfee7a53-a985-4e88-9d48-bbd703cc9d9c:
           RelationalTable:
             DataSourceArn: ${athena_datasource_arn}
-            Catalog: AwsDataCatalog
+            Catalog: ${athena_catalog_name}
             Schema: ${athena_database_name}
             Name: data_collection_logs
             InputColumns:

--- a/dashboards/data-transfer/DataTransfer-Cost-Analysis-Dashboard.yaml
+++ b/dashboards/data-transfer/DataTransfer-Cost-Analysis-Dashboard.yaml
@@ -18,7 +18,7 @@ datasets:
         62e77300-66ee-4669-b257-4823ffd5678a:
           RelationalTable:
             DataSourceArn: ${athena_datasource_arn}
-            Catalog: AwsDataCatalog
+            Catalog: ${athena_catalog_name}
             Schema: ${athena_database_name}
             Name: account_map
             InputColumns:
@@ -29,7 +29,7 @@ datasets:
         f578e7c1-d15d-4068-bb25-988a092a7333:
           RelationalTable:
             DataSourceArn: ${athena_datasource_arn}
-            Catalog: AwsDataCatalog
+            Catalog: ${athena_catalog_name}
             Schema: ${athena_database_name}
             Name: data_transfer_view
             InputColumns:

--- a/dashboards/euc/euc-dashboard.yaml
+++ b/dashboards/euc/euc-dashboard.yaml
@@ -23281,7 +23281,7 @@ datasets:
         af7cf4fe-a3b4-418b-a4e0-fe6dd8160686:
           RelationalTable:
             DataSourceArn: ${athena_datasource_arn}
-            Catalog: AwsDataCatalog
+            Catalog: ${athena_catalog_name}
             Schema: ${athena_database_name}
             Name: euc_metrics_view
             InputColumns:
@@ -23409,7 +23409,7 @@ datasets:
         d77685e6-5f78-44cf-8310-061e54960433:
           RelationalTable:
             DataSourceArn: ${athena_datasource_arn}
-            Catalog: AwsDataCatalog
+            Catalog: ${athena_catalog_name}
             Schema: ${athena_database_name}
             Name: account_map
             InputColumns:
@@ -23518,7 +23518,7 @@ datasets:
         9cbddd15-14cb-427f-8fec-e97abbc35a62:
           RelationalTable:
             DataSourceArn: ${athena_datasource_arn}
-            Catalog: AwsDataCatalog
+            Catalog: ${athena_catalog_name}
             Schema: ${athena_database_name}
             Name: euc_view
             InputColumns:
@@ -23642,7 +23642,7 @@ datasets:
         ce1f1217-e441-438b-bd14-2e0e54d00f77:
           RelationalTable:
             DataSourceArn: ${athena_datasource_arn}
-            Catalog: AwsDataCatalog
+            Catalog: ${athena_catalog_name}
             Schema: ${athena_database_name}
             Name: account_map
             InputColumns:

--- a/dashboards/extended-support-cost-projection/extended-support-cost-projection.yaml
+++ b/dashboards/extended-support-cost-projection/extended-support-cost-projection.yaml
@@ -31,7 +31,7 @@ datasets:
         a201689c-b688-4037-a5ad-6282c4056d01:
           RelationalTable:
             DataSourceArn: ${athena_datasource_arn}
-            Catalog: AwsDataCatalog
+            Catalog: ${athena_catalog_name}
             Schema: ${athena_database_name}
             Name: elasticache_extended_support_view
             InputColumns:
@@ -94,7 +94,7 @@ datasets:
         19e7f4ff-203f-478e-a12e-754ee6a312cb:
           RelationalTable:
             DataSourceArn: ${athena_datasource_arn}
-            Catalog: AwsDataCatalog
+            Catalog: ${athena_catalog_name}
             Schema: ${account_map_database_name}
             Name: account_map
             InputColumns:
@@ -172,7 +172,7 @@ datasets:
         2ae1dbc5-c18b-4751-8473-5864f5e91d44:
           RelationalTable:
             DataSourceArn: ${athena_datasource_arn}
-            Catalog: AwsDataCatalog
+            Catalog: ${athena_catalog_name}
             Schema: ${athena_database_name}
             Name: eks_extended_support_view
             InputColumns:
@@ -215,7 +215,7 @@ datasets:
         effd7cff-853e-45ff-b71d-b08cd0117824:
           RelationalTable:
             DataSourceArn: ${athena_datasource_arn}
-            Catalog: AwsDataCatalog
+            Catalog: ${athena_catalog_name}
             Schema: ${account_map_database_name}
             Name: account_map
             InputColumns:
@@ -285,7 +285,7 @@ datasets:
         0d4de22c-5e16-47c0-bf31-c248baf48499:
           RelationalTable:
             DataSourceArn: ${athena_datasource_arn}
-            Catalog: AwsDataCatalog
+            Catalog: ${athena_catalog_name}
             Schema: ${account_map_database_name}
             Name: account_map
             InputColumns:
@@ -296,7 +296,7 @@ datasets:
         76a6ad9d-caf0-447f-8609-1c4d8fb89673:
           RelationalTable:
             DataSourceArn: ${athena_datasource_arn}
-            Catalog: AwsDataCatalog
+            Catalog: ${athena_catalog_name}
             Schema: ${athena_database_name}
             Name: rds_extended_support_view
             InputColumns:
@@ -444,7 +444,7 @@ datasets:
         b51ef4eb-f8bd-41d1-8ed4-bce50612fb1b:
           RelationalTable:
             DataSourceArn: ${athena_datasource_arn}
-            Catalog: AwsDataCatalog
+            Catalog: ${athena_catalog_name}
             Schema: ${athena_database_name}
             Name: opensearch_extended_support_view
             InputColumns:
@@ -500,7 +500,7 @@ datasets:
         cbd42501-c0e4-4cb5-a85f-50cbaa20776e:
           RelationalTable:
             DataSourceArn: ${athena_datasource_arn}
-            Catalog: AwsDataCatalog
+            Catalog: ${athena_catalog_name}
             Schema: ${account_map_database_name}
             Name: account_map
             InputColumns:
@@ -575,7 +575,7 @@ datasets:
         5a574f8c-5e74-4da8-97cc-4f6802a7d360:
           RelationalTable:
             DataSourceArn: ${athena_datasource_arn}
-            Catalog: AwsDataCatalog
+            Catalog: ${athena_catalog_name}
             Schema: ${athena_database_name}
             Name: extended_support_tagging_view
             InputColumns:
@@ -590,7 +590,7 @@ datasets:
         90e1376c-d426-4481-9af2-e30d8e9a10c1:
           RelationalTable:
             DataSourceArn: ${athena_datasource_arn}
-            Catalog: AwsDataCatalog
+            Catalog: ${athena_catalog_name}
             Schema: ${account_map_database_name}
             Name: account_map
             InputColumns:

--- a/dashboards/focus/focus.yaml
+++ b/dashboards/focus/focus.yaml
@@ -52,7 +52,7 @@ datasets:
         0aacec67-d196-4af2-a2af-d20a8fb3d801:
           RelationalTable:
             DataSourceArn: ${athena_datasource_arn}
-            Catalog: AwsDataCatalog
+            Catalog: ${athena_catalog_name}
             Schema: ${athena_database_name}
             Name: focus_resource_view
             InputColumns:
@@ -259,7 +259,7 @@ datasets:
         61ada434-e3b0-4cdf-ae98-609f1951a8ff:
           RelationalTable:
             DataSourceArn: ${athena_datasource_arn}
-            Catalog: AwsDataCatalog
+            Catalog: ${athena_catalog_name}
             Schema: ${athena_database_name}
             Name: focus_summary_view
             InputColumns:

--- a/dashboards/graviton-savings-dashboard/graviton_savings_dashboard.yaml
+++ b/dashboards/graviton-savings-dashboard/graviton_savings_dashboard.yaml
@@ -24,7 +24,7 @@ datasets:
         25ebc7a6-65b7-47a5-abd8-003128d25bbc:
           RelationalTable:
             DataSourceArn: ${athena_datasource_arn}
-            Catalog: AwsDataCatalog
+            Catalog: ${athena_catalog_name}
             Schema: ${athena_database_name}
             Name: account_map
             InputColumns:
@@ -35,7 +35,7 @@ datasets:
         545587c0-8fb4-4299-9ecd-b6d8987626fa:
           RelationalTable:
             DataSourceArn: ${athena_datasource_arn}
-            Catalog: AwsDataCatalog
+            Catalog: ${athena_catalog_name}
             Schema: ${athena_database_name}
             Name: graviton_opensearch_view
             InputColumns:
@@ -175,7 +175,7 @@ datasets:
         1200c855-886f-45ad-b974-f8e1cc1c4241:
           RelationalTable:
             DataSourceArn: ${athena_datasource_arn}
-            Catalog: AwsDataCatalog
+            Catalog: ${athena_catalog_name}
             Schema: ${athena_database_name}
             Name: graviton_elasticache_view
             InputColumns:
@@ -253,7 +253,7 @@ datasets:
         17470ef2-0a70-405c-8e06-e9ed2d4186cf:
           RelationalTable:
             DataSourceArn: ${athena_datasource_arn}
-            Catalog: AwsDataCatalog
+            Catalog: ${athena_catalog_name}
             Schema: ${athena_database_name}
             Name: account_map
             InputColumns:
@@ -336,7 +336,7 @@ datasets:
         f21ec750-639f-4f51-9ca0-f39b7ff449f3:
           RelationalTable:
             DataSourceArn: ${athena_datasource_arn}
-            Catalog: AwsDataCatalog
+            Catalog: ${athena_catalog_name}
             Schema: ${athena_database_name}
             Name: graviton_mapping
             InputColumns:
@@ -449,7 +449,7 @@ datasets:
         22b8a470-d369-4904-ab86-203f79fd69b4:
           RelationalTable:
             DataSourceArn: ${athena_datasource_arn}
-            Catalog: AwsDataCatalog
+            Catalog: ${athena_catalog_name}
             Schema: ${athena_database_name}
             Name: account_map
             InputColumns:
@@ -460,7 +460,7 @@ datasets:
         999e0f84-a1e1-4241-8698-17abb947484d:
           RelationalTable:
             DataSourceArn: ${athena_datasource_arn}
-            Catalog: AwsDataCatalog
+            Catalog: ${athena_catalog_name}
             Schema: ${athena_database_name}
             Name: graviton_ec2_view
             InputColumns:
@@ -691,7 +691,7 @@ datasets:
         8881bb67-3603-4d41-a2a4-bc0752d99e7e:
           RelationalTable:
             DataSourceArn: ${athena_datasource_arn}
-            Catalog: AwsDataCatalog
+            Catalog: ${athena_catalog_name}
             Schema: ${athena_database_name}
             Name: account_map
             InputColumns:
@@ -702,7 +702,7 @@ datasets:
         acc44c01-556f-450c-9f77-9932c0a76468:
           RelationalTable:
             DataSourceArn: ${athena_datasource_arn}
-            Catalog: AwsDataCatalog
+            Catalog: ${athena_catalog_name}
             Schema: ${athena_database_name}
             Name: graviton_rds_view
             InputColumns:

--- a/dashboards/health-events/health-events.yaml
+++ b/dashboards/health-events/health-events.yaml
@@ -18,7 +18,7 @@ datasets:
         b6e834d2-c61b-4327-a27a-e1d4b53d3d92:
           RelationalTable:
             DataSourceArn: ${athena_datasource_arn}
-            Catalog: AwsDataCatalog
+            Catalog: ${athena_catalog_name}
             Schema: ${athena_database_name}
             Name: health_events_view
             InputColumns:
@@ -107,7 +107,7 @@ datasets:
         fcf163c9-994b-477d-ace3-2c0873880793:
           RelationalTable:
             DataSourceArn: ${athena_datasource_arn}
-            Catalog: AwsDataCatalog
+            Catalog: ${athena_catalog_name}
             Schema: ${athena_database_name}
             Name: account_map
             InputColumns:

--- a/dashboards/kiro-user-activity/kiro-user-activity.yaml
+++ b/dashboards/kiro-user-activity/kiro-user-activity.yaml
@@ -31,7 +31,7 @@ datasets:
         90eb30a0-71b0-4338-b0a0-b8ca792d820a:
           RelationalTable:
             DataSourceArn: ${athena_datasource_arn}
-            Catalog: AwsDataCatalog
+            Catalog: ${athena_catalog_name}
             Schema: ${athena_database_name}
             Name: kiro_user_activity_view
             InputColumns:
@@ -205,7 +205,7 @@ datasets:
         7c1f2a3b-9d84-4c1e-bf20-5a6b7c8d9e01:
           RelationalTable:
             DataSourceArn: ${athena_datasource_arn}
-            Catalog: AwsDataCatalog
+            Catalog: ${athena_catalog_name}
             Schema: ${athena_database_name}
             Name: kiro_cur_view
             InputColumns:

--- a/dashboards/media-services-insights/msih.yaml
+++ b/dashboards/media-services-insights/msih.yaml
@@ -23,7 +23,7 @@ datasets:
         561125b1-707c-4bb5-8612-0de0dd959cbc:
           RelationalTable:
             DataSourceArn: ${athena_datasource_arn}
-            Catalog: AwsDataCatalog
+            Catalog: ${athena_catalog_name}
             Schema: ${athena_database_name}
             Name: account_map
             InputColumns:
@@ -34,7 +34,7 @@ datasets:
         b8ca8419-aec2-4fdc-b918-d863093c891b:
           RelationalTable:
             DataSourceArn: ${athena_datasource_arn}
-            Catalog: AwsDataCatalog
+            Catalog: ${athena_catalog_name}
             Schema: ${athena_database_name}
             Name: account_map
             InputColumns:
@@ -45,7 +45,7 @@ datasets:
         ed097151-78f5-469f-9fca-e38e55537089:
           RelationalTable:
             DataSourceArn: ${athena_datasource_arn}
-            Catalog: AwsDataCatalog
+            Catalog: ${athena_catalog_name}
             Schema: ${athena_database_name}
             Name: msih_reservation_optimize
             InputColumns:
@@ -257,7 +257,7 @@ datasets:
         09e670d1-8b16-4a2f-9e17-2d9ef290ec84:
           RelationalTable:
             DataSourceArn: ${athena_datasource_arn}
-            Catalog: AwsDataCatalog
+            Catalog: ${athena_catalog_name}
             Schema: ${athena_database_name}
             Name: msih_reservations
             InputColumns:
@@ -335,7 +335,7 @@ datasets:
         481b319c-c8f4-4e82-9ddf-fa705f6cf783:
           RelationalTable:
             DataSourceArn: ${athena_datasource_arn}
-            Catalog: AwsDataCatalog
+            Catalog: ${athena_catalog_name}
             Schema: ${athena_database_name}
             Name: account_map
             InputColumns:
@@ -346,7 +346,7 @@ datasets:
         fe517bcf-d790-49f8-b395-b744f079758f:
           RelationalTable:
             DataSourceArn: ${athena_datasource_arn}
-            Catalog: AwsDataCatalog
+            Catalog: ${athena_catalog_name}
             Schema: ${athena_database_name}
             Name: account_map
             InputColumns:
@@ -469,7 +469,7 @@ datasets:
         17740ffc-0df9-4dc9-8780-a77c9dadae18:
           RelationalTable:
             DataSourceArn: ${athena_datasource_arn}
-            Catalog: AwsDataCatalog
+            Catalog: ${athena_catalog_name}
             Schema: ${athena_database_name}
             Name: msih_view
             InputColumns:
@@ -587,7 +587,7 @@ datasets:
         ca2f9216-c240-4505-9a10-3d7794d2633a:
           RelationalTable:
             DataSourceArn: ${athena_datasource_arn}
-            Catalog: AwsDataCatalog
+            Catalog: ${athena_catalog_name}
             Schema: ${athena_database_name}
             Name: account_map
             InputColumns:
@@ -598,7 +598,7 @@ datasets:
         ec2b20b0-73e0-476d-bcb9-7ccd2bcf48db:
           RelationalTable:
             DataSourceArn: ${athena_datasource_arn}
-            Catalog: AwsDataCatalog
+            Catalog: ${athena_catalog_name}
             Schema: ${athena_database_name}
             Name: account_map
             InputColumns:

--- a/dashboards/pca/pca.yaml
+++ b/dashboards/pca/pca.yaml
@@ -1840,7 +1840,7 @@ datasets:
         2e8a5480-2205-48f0-bbd7-5da573d1dd04:
           RelationalTable:
             DataSourceArn: ${athena_datasource_arn}
-            Catalog: AwsDataCatalog
+            Catalog: ${athena_catalog_name}
             Schema: ${athena_database_name}
             Name: pricing_changes
             InputColumns:
@@ -1897,7 +1897,7 @@ datasets:
         c6899647-9846-4860-be8b-a357a4483f38:
           RelationalTable:
             DataSourceArn: ${athena_datasource_arn}
-            Catalog: AwsDataCatalog
+            Catalog: ${athena_catalog_name}
             Schema: ${athena_database_name}
             Name: account_map
             InputColumns:

--- a/dashboards/resilience-vue/resilience-vue.yaml
+++ b/dashboards/resilience-vue/resilience-vue.yaml
@@ -26,7 +26,7 @@ datasets:
         4b549ebe-2b15-409e-b4b9-4dd77bee7438:
           RelationalTable:
             DataSourceArn: ${athena_datasource_arn}
-            Catalog: AwsDataCatalog
+            Catalog: ${athena_catalog_name}
             Schema: ${athena_database_name}
             Name: resiliencehub_resiliency_policy_view
             InputColumns:
@@ -69,7 +69,7 @@ datasets:
         e3c1e20f-e35c-435b-9ec0-2b7e957b0af7:
           RelationalTable:
             DataSourceArn: ${athena_datasource_arn}
-            Catalog: AwsDataCatalog
+            Catalog: ${athena_catalog_name}
             Schema: ${athena_database_name}
             Name: account_map
             InputColumns:
@@ -148,7 +148,7 @@ datasets:
         a1b01e93-9a6b-4175-bd84-f8f8bb54edda:
           RelationalTable:
             DataSourceArn: ${athena_datasource_arn}
-            Catalog: AwsDataCatalog
+            Catalog: ${athena_catalog_name}
             Schema: ${athena_database_name}
             Name: resiliencehub_applications_view
             InputColumns:
@@ -219,7 +219,7 @@ datasets:
         ca6792e7-8cdc-458a-8ee6-7b319ac04c4a:
           RelationalTable:
             DataSourceArn: ${athena_datasource_arn}
-            Catalog: AwsDataCatalog
+            Catalog: ${athena_catalog_name}
             Schema: ${athena_database_name}
             Name: resilience_hub_alarm_recommendations_view
             InputColumns:
@@ -248,7 +248,7 @@ datasets:
         e3c1e20f-e35c-435b-9ec0-2b7e957b0af6:
           RelationalTable:
             DataSourceArn: ${athena_datasource_arn}
-            Catalog: AwsDataCatalog
+            Catalog: ${athena_catalog_name}
             Schema: ${athena_database_name}
             Name: account_map
             InputColumns:
@@ -353,7 +353,7 @@ datasets:
         0225d787-37df-4a1d-9fdc-17b0f0836318:
           RelationalTable:
             DataSourceArn: ${athena_datasource_arn}
-            Catalog: AwsDataCatalog
+            Catalog: ${athena_catalog_name}
             Schema: ${athena_database_name}
             Name: resiliencehub_app_recommendations_view
             InputColumns:
@@ -378,7 +378,7 @@ datasets:
         1ae03acd-73e7-4243-bfd2-be72b34c64c1:
           RelationalTable:
             DataSourceArn: ${athena_datasource_arn}
-            Catalog: AwsDataCatalog
+            Catalog: ${athena_catalog_name}
             Schema: ${athena_database_name}
             Name: resiliencehub_applications_view
             InputColumns:
@@ -449,7 +449,7 @@ datasets:
         e3c1e20f-e35c-435b-9ec0-2b7e957b0af8:
           RelationalTable:
             DataSourceArn: ${athena_datasource_arn}
-            Catalog: AwsDataCatalog
+            Catalog: ${athena_catalog_name}
             Schema: ${athena_database_name}
             Name: account_map
             InputColumns:
@@ -557,7 +557,7 @@ datasets:
         374283c9-0f44-482c-aff3-b9bdd0caa0ac:
           RelationalTable:
             DataSourceArn: ${athena_datasource_arn}
-            Catalog: AwsDataCatalog
+            Catalog: ${athena_catalog_name}
             Schema: ${athena_database_name}
             Name: resiliencehub_applications_view
             InputColumns:
@@ -628,7 +628,7 @@ datasets:
         e3c1e20f-e35c-435b-9ec0-2b7e957b0af9:
           RelationalTable:
             DataSourceArn: ${athena_datasource_arn}
-            Catalog: AwsDataCatalog
+            Catalog: ${athena_catalog_name}
             Schema: ${athena_database_name}
             Name: account_map
             InputColumns:
@@ -713,7 +713,7 @@ datasets:
         5ddffa0d-502a-431d-b99e-ace62085c0ec:
           RelationalTable:
             DataSourceArn: ${athena_datasource_arn}
-            Catalog: AwsDataCatalog
+            Catalog: ${athena_catalog_name}
             Schema: ${athena_database_name}
             Name: resiliencehub_complete_view
             InputColumns:
@@ -816,7 +816,7 @@ datasets:
         c2e9b0ea-d31a-4855-b2ff-a7250b236f92:
           RelationalTable:
             DataSourceArn: ${athena_datasource_arn}
-            Catalog: AwsDataCatalog
+            Catalog: ${athena_catalog_name}
             Schema: ${athena_database_name}
             Name: resiliencehub_applications_view
             InputColumns:
@@ -887,7 +887,7 @@ datasets:
         c35444df-c780-442f-b519-7eed83b0eb34:
           RelationalTable:
             DataSourceArn: ${athena_datasource_arn}
-            Catalog: AwsDataCatalog
+            Catalog: ${athena_catalog_name}
             Schema: ${athena_database_name}
             Name: account_map
             InputColumns:
@@ -1216,7 +1216,7 @@ datasets:
         08552140-425b-4db9-8f41-94d1b639ee84:
           RelationalTable:
             DataSourceArn: ${athena_datasource_arn}
-            Catalog: AwsDataCatalog
+            Catalog: ${athena_catalog_name}
             Schema: ${athena_database_name}
             Name: resiliencehub_daily_assessments_view
             InputColumns:
@@ -1281,7 +1281,7 @@ datasets:
         dddbce52-5b96-4d62-9d46-3e676d14dafb:
           RelationalTable:
             DataSourceArn: ${athena_datasource_arn}
-            Catalog: AwsDataCatalog
+            Catalog: ${athena_catalog_name}
             Schema: ${athena_database_name}
             Name: account_map
             InputColumns:
@@ -1417,7 +1417,7 @@ datasets:
         4d63d09e-8eca-4a79-8419-672c6c614fc2:
           RelationalTable:
             DataSourceArn: ${athena_datasource_arn}
-            Catalog: AwsDataCatalog
+            Catalog: ${athena_catalog_name}
             Schema: ${athena_database_name}
             Name: resiliencehub_fis_test_recommendations_view
             InputColumns:
@@ -1446,7 +1446,7 @@ datasets:
         ad502496-1d2e-4a21-96fb-2ec750f343ca:
           RelationalTable:
             DataSourceArn: ${athena_datasource_arn}
-            Catalog: AwsDataCatalog
+            Catalog: ${athena_catalog_name}
             Schema: ${athena_database_name}
             Name: resiliencehub_applications_view
             InputColumns:
@@ -1517,7 +1517,7 @@ datasets:
         b79055ee-a61f-459d-a103-4914289d7620:
           RelationalTable:
             DataSourceArn: ${athena_datasource_arn}
-            Catalog: AwsDataCatalog
+            Catalog: ${athena_catalog_name}
             Schema: ${athena_database_name}
             Name: account_map
             InputColumns:
@@ -1626,7 +1626,7 @@ datasets:
         90d7b3ce-088b-4ea8-bf12-92f26943ef7e:
           RelationalTable:
             DataSourceArn: ${athena_datasource_arn}
-            Catalog: AwsDataCatalog
+            Catalog: ${athena_catalog_name}
             Schema: ${athena_database_name}
             Name: resiliencehub_resource_types_view
             InputColumns:
@@ -1647,7 +1647,7 @@ datasets:
         c6cad87b-2018-4170-b3b3-3d11ee2d0293:
           RelationalTable:
             DataSourceArn: ${athena_datasource_arn}
-            Catalog: AwsDataCatalog
+            Catalog: ${athena_catalog_name}
             Schema: ${athena_database_name}
             Name: account_map
             InputColumns:
@@ -1711,7 +1711,7 @@ datasets:
         4baab758-4f80-4394-891a-ea6d129d9eb7:
           RelationalTable:
             DataSourceArn: ${athena_datasource_arn}
-            Catalog: AwsDataCatalog
+            Catalog: ${athena_catalog_name}
             Schema: ${athena_database_name}
             Name: account_map
             InputColumns:
@@ -1722,7 +1722,7 @@ datasets:
         bf7d1c7b-afff-455b-9010-39a34a7bdd83:
           RelationalTable:
             DataSourceArn: ${athena_datasource_arn}
-            Catalog: AwsDataCatalog
+            Catalog: ${athena_catalog_name}
             Schema: ${athena_database_name}
             Name: resiliencehub_sop_recommendations_view
             InputColumns:
@@ -1751,7 +1751,7 @@ datasets:
         c2483319-f729-4f18-9cd2-1bb7f6cb79ad:
           RelationalTable:
             DataSourceArn: ${athena_datasource_arn}
-            Catalog: AwsDataCatalog
+            Catalog: ${athena_catalog_name}
             Schema: ${athena_database_name}
             Name: resiliencehub_applications_view
             InputColumns:

--- a/dashboards/rls/rls.yaml
+++ b/dashboards/rls/rls.yaml
@@ -19,7 +19,7 @@ datasets:
         625fab9d-ce94-4690-a7bf-142b0996ddda:
           RelationalTable:
             DataSourceArn: ${athena_datasource_arn}
-            Catalog: AwsDataCatalog
+            Catalog: ${athena_catalog_name}
             Schema: ${athena_database_name}
             Name: rls_dataset
             InputColumns:
@@ -51,7 +51,7 @@ datasets:
         a4a17683-2fe9-4d08-9935-95ed1af884bb:
           RelationalTable:
             DataSourceArn: ${athena_datasource_arn}
-            Catalog: AwsDataCatalog
+            Catalog: ${athena_catalog_name}
             Schema: ${athena_database_name}
             Name: rls_all_users_view
             InputColumns:

--- a/dashboards/scad-containers-cost-allocation/scad-containers-cost-allocation.yaml
+++ b/dashboards/scad-containers-cost-allocation/scad-containers-cost-allocation.yaml
@@ -17,7 +17,7 @@ datasets:
         53c5ae59-b21c-41b6-9d4e-4818f4e2a8d6:
           RelationalTable:
             DataSourceArn: ${athena_datasource_arn}
-            Catalog: AwsDataCatalog
+            Catalog: ${athena_catalog_name}
             Schema: ${athena_database_name}
             Name: account_map
             InputColumns:
@@ -28,7 +28,7 @@ datasets:
         67b570dd-8eb4-4623-ac3a-5ce15c6faf2c:
           RelationalTable:
             DataSourceArn: ${athena_datasource_arn}
-            Catalog: AwsDataCatalog
+            Catalog: ${athena_catalog_name}
             Schema: ${athena_database_name}
             Name: scad_cca_summary_view_data_on_eks
             InputColumns:
@@ -436,7 +436,7 @@ datasets:
         320f3b02-0ba2-4d14-b684-1a5431781f39:
           RelationalTable:
             DataSourceArn: ${athena_datasource_arn}
-            Catalog: AwsDataCatalog
+            Catalog: ${athena_catalog_name}
             Schema: ${athena_database_name}
             Name: account_map
             InputColumns:
@@ -447,7 +447,7 @@ datasets:
         40065454-2867-4119-8240-618f4332aa7e:
           RelationalTable:
             DataSourceArn: ${athena_datasource_arn}
-            Catalog: AwsDataCatalog
+            Catalog: ${athena_catalog_name}
             Schema: ${athena_database_name}
             Name: scad_cca_summary_view
             InputColumns:

--- a/dashboards/shard/shard.yaml
+++ b/dashboards/shard/shard.yaml
@@ -13807,7 +13807,7 @@ datasets:
         93eee313-96a4-4f70-9f21-698add7064c3:
           RelationalTable:
             DataSourceArn: ${athena_datasource_arn}
-            Catalog: AwsDataCatalog
+            Catalog: ${athena_catalog_name}
             Schema: ${athena_database_name}
             Name: security_hub_findings
             InputColumns:

--- a/dashboards/support-cases-radar/support-cases-radar.yaml
+++ b/dashboards/support-cases-radar/support-cases-radar.yaml
@@ -18,7 +18,7 @@ datasets:
         24d7d4f8-c978-4377-b7f2-5f1db7c616a8:
           RelationalTable:
             DataSourceArn: ${athena_datasource_arn}
-            Catalog: AwsDataCatalog
+            Catalog: ${athena_catalog_name}
             Schema: ${athena_database_name}
             Name: support_cases_status_view
             InputColumns:
@@ -53,7 +53,7 @@ datasets:
         bb496e3a-0c1b-4711-a115-f63cb9cdc045:
           RelationalTable:
             DataSourceArn: ${athena_datasource_arn}
-            Catalog: AwsDataCatalog
+            Catalog: ${athena_catalog_name}
             Schema: ${athena_database_name}
             Name: account_map
             InputColumns:
@@ -64,7 +64,7 @@ datasets:
         cddcae52-1ce1-43ed-bf75-4883a0830a81:
           RelationalTable:
             DataSourceArn: ${athena_datasource_arn}
-            Catalog: AwsDataCatalog
+            Catalog: ${athena_catalog_name}
             Schema: ${athena_database_name}
             Name: support_cases_communications_view
             InputColumns:

--- a/dashboards/sustainability-proxy-metrics/sustainability-proxy-metrics.yaml
+++ b/dashboards/sustainability-proxy-metrics/sustainability-proxy-metrics.yaml
@@ -4059,7 +4059,7 @@ datasets:
         2ca2f9db-d270-4f8f-8e0d-cce6f039328f:
           RelationalTable:
             DataSourceArn: ${athena_datasource_arn}
-            Catalog: AwsDataCatalog
+            Catalog: ${athena_catalog_name}
             Schema: ${athena_database_name}
             Name: sus_s3_storage_all
             InputColumns:
@@ -4111,7 +4111,7 @@ datasets:
         fe1b70ec-a568-4341-9265-db2fe41e6a13:
           RelationalTable:
             DataSourceArn: ${athena_datasource_arn}
-            Catalog: AwsDataCatalog
+            Catalog: ${athena_catalog_name}
             Schema: ${athena_database_name}
             Name: account_map
             InputColumns:
@@ -4177,7 +4177,7 @@ datasets:
         4494af6c-2a55-46c4-9e3d-20dac6d18946:
           RelationalTable:
             DataSourceArn: ${athena_datasource_arn}
-            Catalog: AwsDataCatalog
+            Catalog: ${athena_catalog_name}
             Schema: ${athena_database_name}
             Name: account_map
             InputColumns:
@@ -4188,7 +4188,7 @@ datasets:
         89bda628-8355-4af1-9282-7882fb99dead:
           RelationalTable:
             DataSourceArn: ${athena_datasource_arn}
-            Catalog: AwsDataCatalog
+            Catalog: ${athena_catalog_name}
             Schema: ${athena_database_name}
             Name: sus_carbon_emissions
             InputColumns:
@@ -4311,7 +4311,7 @@ datasets:
         862dc931-5aeb-45bd-aa09-0560920c43f0:
           RelationalTable:
             DataSourceArn: ${athena_datasource_arn}
-            Catalog: AwsDataCatalog
+            Catalog: ${athena_catalog_name}
             Schema: ${athena_database_name}
             Name: sus_compute_ec2
             InputColumns:
@@ -4339,7 +4339,7 @@ datasets:
         937e5fa9-bb37-4b63-a607-f8c1d0a7ca9b:
           RelationalTable:
             DataSourceArn: ${athena_datasource_arn}
-            Catalog: AwsDataCatalog
+            Catalog: ${athena_catalog_name}
             Schema: ${athena_database_name}
             Name: account_map
             InputColumns:
@@ -4394,7 +4394,7 @@ datasets:
         8d1ead4d-1a2e-4641-947a-d8ffb40d653e:
           RelationalTable:
             DataSourceArn: ${athena_datasource_arn}
-            Catalog: AwsDataCatalog
+            Catalog: ${athena_catalog_name}
             Schema: ${athena_database_name}
             Name: account_map
             InputColumns:
@@ -4405,7 +4405,7 @@ datasets:
         961a6efd-2ed4-4d1c-8f5a-e7ff676393c8:
           RelationalTable:
             DataSourceArn: ${athena_datasource_arn}
-            Catalog: AwsDataCatalog
+            Catalog: ${athena_catalog_name}
             Schema: ${athena_database_name}
             Name: sus_idle_elb
             InputColumns:
@@ -4485,7 +4485,7 @@ datasets:
         d88e946b-50c5-4131-af7f-a20c19b5f44d:
           RelationalTable:
             DataSourceArn: ${athena_datasource_arn}
-            Catalog: AwsDataCatalog
+            Catalog: ${athena_catalog_name}
             Schema: ${athena_database_name}
             Name: sus_storage_athena
             InputColumns:
@@ -4509,7 +4509,7 @@ datasets:
         e7b46e3d-87cf-473e-908b-7870ffa90a32:
           RelationalTable:
             DataSourceArn: ${athena_datasource_arn}
-            Catalog: AwsDataCatalog
+            Catalog: ${athena_catalog_name}
             Schema: ${athena_database_name}
             Name: account_map
             InputColumns:
@@ -4562,7 +4562,7 @@ datasets:
         2d73b781-2ce6-41a2-9ba0-a193d7aba3ec:
           RelationalTable:
             DataSourceArn: ${athena_datasource_arn}
-            Catalog: AwsDataCatalog
+            Catalog: ${athena_catalog_name}
             Schema: ${athena_database_name}
             Name: sus_geo_region_athena
             InputColumns:
@@ -4630,7 +4630,7 @@ datasets:
         4f66d90f-5d4a-4e8e-bcdf-2e83d73d37a8:
           RelationalTable:
             DataSourceArn: ${athena_datasource_arn}
-            Catalog: AwsDataCatalog
+            Catalog: ${athena_catalog_name}
             Schema: ${athena_database_name}
             Name: account_map
             InputColumns:
@@ -4641,7 +4641,7 @@ datasets:
         b4b4e384-904f-42b3-9108-3dff4ad53b30:
           RelationalTable:
             DataSourceArn: ${athena_datasource_arn}
-            Catalog: AwsDataCatalog
+            Catalog: ${athena_catalog_name}
             Schema: ${athena_database_name}
             Name: sus_network
             InputColumns:
@@ -4739,7 +4739,7 @@ datasets:
         3dd3174f-61ea-420e-8ea9-d7fb30a929ef:
           RelationalTable:
             DataSourceArn: ${athena_datasource_arn}
-            Catalog: AwsDataCatalog
+            Catalog: ${athena_catalog_name}
             Schema: ${athena_database_name}
             Name: sus_compute_split
             InputColumns:
@@ -4763,7 +4763,7 @@ datasets:
         7c5b80e9-7ba4-42bd-b626-4f8500c0ef00:
           RelationalTable:
             DataSourceArn: ${athena_datasource_arn}
-            Catalog: AwsDataCatalog
+            Catalog: ${athena_catalog_name}
             Schema: ${athena_database_name}
             Name: account_map
             InputColumns:
@@ -4816,7 +4816,7 @@ datasets:
         0766af2c-5154-4b8a-a5df-8d9a2d37efb4:
           RelationalTable:
             DataSourceArn: ${athena_datasource_arn}
-            Catalog: AwsDataCatalog
+            Catalog: ${athena_catalog_name}
             Schema: ${athena_database_name}
             Name: account_map
             InputColumns:
@@ -4827,7 +4827,7 @@ datasets:
         30332fbc-ad6f-47ec-b5d2-c6bd31f5efc4:
           RelationalTable:
             DataSourceArn: ${athena_datasource_arn}
-            Catalog: AwsDataCatalog
+            Catalog: ${athena_catalog_name}
             Schema: ${athena_database_name}
             Name: sus_idle_natgw
             InputColumns:

--- a/dashboards/tao/tao.yaml
+++ b/dashboards/tao/tao.yaml
@@ -19,7 +19,7 @@ datasets:
         30d52db3-daf0-4f90-9716-52ba236f446d:
           RelationalTable:
             DataSourceArn: ${athena_datasource_arn}
-            Catalog: AwsDataCatalog
+            Catalog: ${athena_catalog_name}
             Schema: ${athena_database_name}
             Name: ta_priority_org_view
             InputColumns:
@@ -72,7 +72,7 @@ datasets:
         78030af5-de76-4ef2-919e-492e863297d7:
           RelationalTable:
             DataSourceArn: ${athena_datasource_arn}
-            Catalog: AwsDataCatalog
+            Catalog: ${athena_catalog_name}
             Schema: ${athena_database_name}
             Name: account_map
             InputColumns:
@@ -234,7 +234,7 @@ datasets:
         99142d9e-0831-40c4-8744-261696fb2f12:
           RelationalTable:
             DataSourceArn: ${athena_datasource_arn}
-            Catalog: AwsDataCatalog
+            Catalog: ${athena_catalog_name}
             Schema: ${athena_database_name}
             Name: account_map
             InputColumns:

--- a/dashboards/unit-cost-dashboard/unit-cost-dashboard.yaml
+++ b/dashboards/unit-cost-dashboard/unit-cost-dashboard.yaml
@@ -18,7 +18,7 @@ datasets:
         700593a6-2e53-466b-81b6-8ac852fd32ea:
           RelationalTable:
             DataSourceArn: ${athena_datasource_arn}
-            Catalog: AwsDataCatalog
+            Catalog: ${athena_catalog_name}
             Schema: ${athena_database_name}
             Name: unitcost_view
             InputColumns:
@@ -97,7 +97,7 @@ datasets:
         e25bcf6f-d78e-47c4-b730-cb0e0242cda2:
           RelationalTable:
             DataSourceArn: ${athena_datasource_arn}
-            Catalog: AwsDataCatalog
+            Catalog: ${athena_catalog_name}
             Schema: ${athena_database_name}
             Name: account_map
             InputColumns:


### PR DESCRIPTION
Propagate selected Glue Data Catalog to dataset templates and IAM policies

Previously, when users selected a non-default Glue Data Catalog, the selection was ignored — datasets, YAML dashboards, IAM policies, and exports all hardcoded 'AwsDataCatalog'.

Changes:
- Add athena_catalog_name template variable to columns_tpl (common.py)
- Replace hardcoded Catalog in 6 JSON dataset templates with template var
- Replace hardcoded Catalog in 25 YAML dashboard definitions (118 occurrences)
- Parameterize IAM policy datacatalog ARN in iam.py (with backward-compat default)
- Templatize Catalog field in export.py so future exports use the variable
- Add property-based tests for bug condition and preservation

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
